### PR TITLE
feat: Play Soundcloud tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ffmpeg-static": "^4.1.1",
     "merge-options": "^2.0.0",
     "simple-youtube-api": "^5.2.1",
+    "soundcloud-downloader": "0.0.9",
     "ytdl-core": "^3.0.0"
   },
   "devDependencies": {

--- a/src/Player.js
+++ b/src/Player.js
@@ -114,7 +114,7 @@ class Player {
             let song;
             
             // First check if its a Soundcloud URL
-            if (this.soundcloudClientID && Util.isSoundcloudURL(songName)) {
+            if (this.soundcloudClientID !== undefined && Util.isSoundcloudURL(songName)) {
                 const info = await Util.getSoundcloudTrackInfo(songName, this.soundcloudClientID);
                 song = new SoundcloudSong(info, queue, requestedBy);
                 
@@ -237,7 +237,7 @@ class Player {
             let queue = this.queues.find((g) => g.guildID === guildID);
             if(!queue) return reject('Not playing');
             let song;
-            if (this.soundcloudClientID && Util.isSoundcloudURL(songName)) {
+            if (this.soundcloudClientID !== undefined && Util.isSoundcloudURL(songName)) {
                 const info = await Util.getSoundcloudTrackInfo(songName, this.soundcloudClientID);
                 song = new SoundcloudSong(info, queue, requestedBy);
             } else {
@@ -420,7 +420,7 @@ class Player {
         // Download the song
         let dispatcher 
         if (song.constructor.name === 'SoundcloudSong') {
-            dispatcher = queue.connection.play(await scdl.downloadFromURL(song.url))
+            dispatcher = queue.connection.play(await scdl.downloadFromURL(song.url, this.soundcloudClientID))
         } else {
             dispatcher = queue.connection.play(ytdl(song.url, { filter: "audioonly" }));
         }

--- a/src/Player.js
+++ b/src/Player.js
@@ -236,10 +236,16 @@ class Player {
             // Gets guild queue
             let queue = this.queues.find((g) => g.guildID === guildID);
             if(!queue) return reject('Not playing');
-            // Searches the song
-            let video = await Util.getFirstYoutubeResult(songName, this.SYA).catch(() => {});
-            if(!video) return reject('Song not found');
-            let song = new Song(video, queue, requestedBy);
+            let song;
+            if (this.soundcloudClientID && Util.isSoundcloudURL(songName)) {
+                const info = await Util.getSoundcloudTrackInfo(songName, this.soundcloudClientID);
+                song = new SoundcloudSong(info, queue, requestedBy);
+            } else {
+                // Searches the song
+                let video = await Util.getFirstYoutubeResult(songName, this.SYA).catch(() => {});
+                if(!video) return reject('Song not found');
+                song = new Song(video, queue, requestedBy);
+            }
             // Updates queue
             queue.songs.push(song);
             // Resolves the song

--- a/src/SouncloudSong.js
+++ b/src/SouncloudSong.js
@@ -1,0 +1,14 @@
+const Song = require('./Song')
+
+class SoundcloudSong extends Song {
+
+    constructor(trackInfo, queue, requestedBy) {
+        this.name = trackInfo.title
+        this.duration = trackInfo.duration
+        this.author = trackInfo.user.username
+        this.url = trackInfo.media.transcodings[0].url
+        this.thumbnail = trackInfo.artwork_url
+        this.queue = queue
+        this.requestedBy = requestedBy
+    }
+}

--- a/src/SouncloudSong.js
+++ b/src/SouncloudSong.js
@@ -1,6 +1,6 @@
 const Song = require('./Song')
 
-class SoundcloudSong extends Song {
+class SoundcloudSong {
 
     constructor(trackInfo, queue, requestedBy) {
         this.name = trackInfo.title
@@ -12,3 +12,5 @@ class SoundcloudSong extends Song {
         this.requestedBy = requestedBy
     }
 }
+
+module.exports = SoundcloudSong

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,4 +1,6 @@
 const fetch = require('node-fetch');
+const URL = require('url').URL
+const scdl = require('soundcloud-downloader')
 
 /**
  * Utilities.
@@ -42,6 +44,32 @@ class Util {
                 }
             });
         });
+    }
+
+    /**
+     * Checks if the given input string is a Soundcloud URL
+     * @param {string} input The url of the soundcloud track
+     */
+    static isSoundcloudURL(input){
+        try {
+            const url = new URL(input); // Throws a TypeError if the input is invalid
+            if (url.hostname !== 'soundcloud.com') return false;
+            if (url.pathname === '/') return false;
+            return true;
+        } catch (err) {
+            return false;
+        }
+    }
+
+    /**
+     * 
+     * @param {string} url The url of the soundcloud track
+     * @param {string} clientID A Soundcloud client ID
+     * @returns {Promise<SoundcloudSong>} An object with a similar interface to the YouTube video object
+     * so it can be used interchangeably.
+     */
+    static async getSoundcloudTrackInfo(url, clientID){
+        return await scdl.getInfo(url, clientID);
     }
 
 };


### PR DESCRIPTION
I added the the ability to play Soundcloud tracks. I made a new class called `SoundcloudSong` and tried to mirror it as close as possible to the `Song` class, so both can be used interchangeably. This class is constructed with track information retrieved from calling the module [soundcloud-downloader](https://github.com/zackradisic/node-soundcloud-downloader), which also takes care of playing the track.

I also changed `Player::play(voiceChannel, songName, requestedBy)` and `Player::addToQueue(guildID, songName, requestedBy)` to check if `songName` is a Soundcloud URL and then it fetches the track info and creates a `SoundcloudSong` object which is added to the queue.

Additionally, `Player::_playSong(guildID, firstPlay)` now determines if the song is a YouTube video or Soundcloud track and uses the correct interface to play it.


note: I think it would be a good idea to make the Song class more abstract, so other song types can be more easily implemented.