### PR TITLE
remove normalizer from bassboost filter

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -29,7 +29,7 @@ const Track = require('./Track')
  */
 
 const filters = {
-    bassboost: 'bass=g=20,dynaudnorm=f=200',
+    bassboost: 'bass=g=20',
     '8D': 'apulsator=hz=0.08',
     vaporwave: 'aresample=48000,asetrate=48000*0.8',
     nightcore: 'aresample=48000,asetrate=48000*1.25',


### PR DESCRIPTION
Users have to set `normalizer: true` in filters option if they want normalized bassboost. By default, bass should be applied without normalizer