### PR TITLE
Set ytpl.do_warn_deprecate to false

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -2,6 +2,7 @@ const ytdl = require('discord-ytdl-core')
 const Discord = require('discord.js')
 const ytsr = require('ytsr')
 const ytpl = require('ytpl')
+ytpl.do_warn_deprecate = false
 const spotify = require('spotify-url-info')
 const Queue = require('./Queue')
 const Track = require('./Track')


### PR DESCRIPTION
I think that this needs to be changed, because the following message is very annoying and clogs up logs:
```
/*****************************************************************************************************
 * validateURL will be renamed to validateID to match with getPlaylistID in the next release of ytpl *
 *                   set `ytpl.do_warn_deprecate = false` to disable this message                    *
 *****************************************************************************************************/
```