### PR TITLE
Remove deprecation warning of ytpl

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -2,6 +2,7 @@ const ytdl = require('discord-ytdl-core')
 const Discord = require('discord.js')
 const ytsr = require('ytsr')
 const ytpl = require('ytpl')
+ytpl.do_warn_deprecate = false
 const spotify = require('spotify-url-info')
 const Queue = require('./Queue')
 const Track = require('./Track')

--- a/src/Player.js
+++ b/src/Player.js
@@ -159,13 +159,13 @@ class Player {
      *          // Search for tracks
      *          let tracks = await client.player.searchTracks(args[0]);
      *          // Sends an embed with the 10 first songs
-     *          if(tracks.length > 10) tracks = tracks.substr(0, 10);
+     *          if(tracks.length > 10) tracks = tracks.slice(0, 10);
      *          const embed = new Discord.MessageEmbed()
      *          .setDescription(tracks.map((t, i) => `**${i+1} -** ${t.name}`).join("\n"))
      *          .setFooter("Send the number of the track you want to play!");
      *          message.channel.send(embed);
      *          // Wait for user answer
-     *          await message.channel.awaitMessages((m) => m.content > 0 && m.content < 10, { max: 1, time: 20000, errors: ["time"] }).then(async (answers) => {
+     *          await message.channel.awaitMessages((m) => m.content > 0 && m.content < 11, { max: 1, time: 20000, errors: ["time"] }).then(async (answers) => {
      *              let index = parseInt(answers.first().content, 10);
      *              track = track[index-1];
      *              // Then play the song


### PR DESCRIPTION
Warning:
```js
/*****************************************************************************************************
 * validateURL will be renamed to validateID to match with getPlaylistID in the next release of ytpl *
 *                   set `ytpl.do_warn_deprecate = false` to disable this message                    *
 *****************************************************************************************************/
```