### PR TITLE
feat: ability to play soundcloud tracks/playlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "discord-ytdl-core": "^4.0.2",
     "merge-options": "^2.0.0",
     "node-fetch": "^2.6.0",
+    "soundcloud-downloader": "^0.1.6",
     "spotify-url-info": "^1.3.1",
     "ytpl": "^0.2.0",
     "ytsr": "^0.1.19"

--- a/src/Player.js
+++ b/src/Player.js
@@ -159,13 +159,13 @@ class Player {
      *          // Search for tracks
      *          let tracks = await client.player.searchTracks(args[0]);
      *          // Sends an embed with the 10 first songs
-     *          if(tracks.length > 10) tracks = tracks.substr(0, 10);
+     *          if(tracks.length > 10) tracks = tracks.slice(0, 10);
      *          const embed = new Discord.MessageEmbed()
      *          .setDescription(tracks.map((t, i) => `**${i+1} -** ${t.name}`).join("\n"))
      *          .setFooter("Send the number of the track you want to play!");
      *          message.channel.send(embed);
      *          // Wait for user answer
-     *          await message.channel.awaitMessages((m) => m.content > 0 && m.content < 10, { max: 1, time: 20000, errors: ["time"] }).then(async (answers) => {
+     *          await message.channel.awaitMessages((m) => m.content > 0 && m.content < 11, { max: 1, time: 20000, errors: ["time"] }).then(async (answers) => {
      *              let index = parseInt(answers.first().content, 10);
      *              track = track[index-1];
      *              // Then play the song


### PR DESCRIPTION
Hey, I made a similar PR a couple months ago but I'm not sure what happened to the changes I made. Anyhow, I updated the soundcloud-downloader module to support playing playlists and think this would be a nice addition to discord-player. I've tested this with playing tracks and playlists, but I'm not familiar with any nuances of the codebase that might present a problem.