### PR TITLE
♻️ Throw Error instead of Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ client.player
 .on('botDisconnect', (message, queue) => message.channel.send('Music stopped as I have been disconnected from the channel!'))
 
 // Error handling
-.on('error', (message, error) => {
+.on('error', (error, message) => {
     switch(error){
         case 'NotPlaying':
             message.channel.send('There is no music being played on this server!')

--- a/src/Player.js
+++ b/src/Player.js
@@ -301,7 +301,7 @@ class Player extends EventEmitter {
             this.emit('playlistAdd', message, queue, playlist)
         } else {
             const track = new Track(playlist.tracks.shift(), message.author)
-            const queue = await this._createQueue(message, track).catch((e) => this.emit('error', message, e))
+            const queue = await this._createQueue(message, track).catch((e) => this.emit('error', e, message))
             this._addTracksToQueue(message, playlist.tracks)
         }
     }
@@ -369,7 +369,7 @@ class Player extends EventEmitter {
     resume (message) {
         // Get guild queue
         const queue = this.queues.find((g) => g.guildID === message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Pause the dispatcher
         queue.voiceConnection.dispatcher.resume()
         queue.paused = false
@@ -386,7 +386,7 @@ class Player extends EventEmitter {
     stop (message) {
         // Get guild queue
         const queue = this.queues.find((g) => g.guildID === message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Stop the dispatcher
         queue.stopped = true
         queue.tracks = []
@@ -407,7 +407,7 @@ class Player extends EventEmitter {
     setVolume (message, percent) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Update volume
         queue.volume = percent
         queue.voiceConnection.dispatcher.setVolumeLogarithmic(queue.calculatedVolume / 200)
@@ -434,7 +434,7 @@ class Player extends EventEmitter {
     clearQueue (message) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Clear queue
         queue.tracks = []
         // Return the queue
@@ -449,7 +449,7 @@ class Player extends EventEmitter {
     skip (message) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         const currentTrack = queue.playing
         // End the dispatcher
         queue.voiceConnection.dispatcher.end()
@@ -466,7 +466,7 @@ class Player extends EventEmitter {
     nowPlaying (message) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         const currentTrack = queue.tracks[0]
         // Return the current track
         return currentTrack
@@ -481,7 +481,7 @@ class Player extends EventEmitter {
     setRepeatMode (message, enabled) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Enable/Disable repeat mode
         queue.repeatMode = enabled
         // Return the repeat mode
@@ -496,7 +496,7 @@ class Player extends EventEmitter {
     shuffle (message) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Shuffle the queue (except the first track)
         const currentTrack = queue.tracks.shift()
         queue.tracks = queue.tracks.sort(() => Math.random() - 0.5)
@@ -514,7 +514,7 @@ class Player extends EventEmitter {
     remove (message, track) {
         // Get guild queue
         const queue = this.queues.get(message.guild.id)
-        if (!queue) return this.emit('error', message, 'NotPlaying')
+        if (!queue) return this.emit('error', 'NotPlaying', message)
         // Remove the track from the queue
         let trackFound = null
         if (typeof track === 'number') {


### PR DESCRIPTION
Throw `Error` instead of `Message` if `Player` does not have any listeners registered for the `error` event.