### PR TITLE
Added Track as a valid query type for play() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "homepage": "https://github.com/Androz2091/discord-player#readme",
   "dependencies": {
+    "@types/node": "^14.14.7",
     "discord-ytdl-core": "^4.1.3",
     "merge-options": "^2.0.0",
     "moment": "^2.27.0",

--- a/src/Player.js
+++ b/src/Player.js
@@ -319,9 +319,9 @@ class Player extends EventEmitter {
     }
 
     /**
-     * Play a track in the server. Supported query types are `keywords`, YouTube video links`, `YouTube playlists links`, Spotify track link` or `SoundCloud song link`.
-     * @param {Discord.Message} message
-     * @param {String} query
+     * Play a track in the server. Supported query types are `keywords`, `YouTube video links`, `YouTube playlists links`, `Spotify track link` or `SoundCloud song link`.
+     * @param {Discord.Message} message Discord `message`
+     * @param {(String|Track)} query Search query or a valid `Track` object.
      * @returns {Promise<void>}
      *
      * @example

--- a/src/Player.js
+++ b/src/Player.js
@@ -321,7 +321,7 @@ class Player extends EventEmitter {
     /**
      * Play a track in the server. Supported query types are `keywords`, `YouTube video links`, `YouTube playlists links`, `Spotify track link` or `SoundCloud song link`.
      * @param {Discord.Message} message Discord `message`
-     * @param {(String|Track)} query Search query or a valid `Track` object.
+     * @param {String|Track} query Search query or a valid `Track` object.
      * @returns {Promise<void>}
      *
      * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -25,7 +25,7 @@ declare module 'discord-player' {
 
         public isPlaying(message: Message): boolean;
         public setFilters(message: Message, newFilters: Partial<Filters>): Promise<void>;
-        public play(message: Message, query: string): Promise<void>;
+        public play(message: Message, query: string | Track): Promise<void>;
         public pause(message: Message): void;
         public resume(message: Message): void;
         public stop(message: Message): void;


### PR DESCRIPTION
Small PR that just serves to allow for a `Track`object to be a valid query type for the main play() method. I saw that the code supported a Track object, so thought it might be a good idea to add it.

- Types updated in both `typings\index.d.ts` and inline JSDocs
- Also added `@types/node` package to prevent IDE's from yelling when editing the index.d.ts