### PR TITLE
trackStart Event Standardization

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -313,7 +313,7 @@ class Player extends EventEmitter {
         } else {
             const track = playlist.tracks.shift()
             const queue = await this._createQueue(message, track).catch((e) => this.emit('error', e, message))
-            this.emit('trackStart', message, queue.tracks[0])
+            this.emit('trackStart', message, queue.tracks[0], queue)
             this._addTracksToQueue(message, playlist.tracks)
         }
     }
@@ -357,7 +357,7 @@ class Player extends EventEmitter {
                 this.emit('trackAdd', message, queue, queue.tracks[queue.tracks.length - 1])
             } else {
                 const queue = await this._createQueue(message, trackToPlay)
-                this.emit('trackStart', message, queue.tracks[0])
+                this.emit('trackStart', message, queue.tracks[0], queue)
             }
         }
     }
@@ -705,8 +705,8 @@ module.exports = Player
  * Emitted when a track starts
  * @event Player#trackStart
  * @param {Discord.Message} message
- * @param {Queue} queue
  * @param {Track} track
+ * @param {Queue} queue
  */
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -73,7 +73,7 @@ declare module 'discord-player' {
         noResults: [Message, string];
         playlistAdd: [Message, Queue, Playlist];
         trackAdd: [Message, Queue, Track];
-        trackStart: [Message, Track];
+        trackStart: [Message, Track, Queue];
         botDisconnect: [Message];
         channelEmpty: [Message, Queue];
         musicStop: [];


### PR DESCRIPTION
This PR serves to standardize the event arguments and types supplied by the 'startTrack' event. I went with the most common structure already present in the code. All of the events should now have the same arguments.

Types were also changed in the inline JSDocs and `index.d.ts` to reflect this.