### PR TITLE
Added back ytpl and improved Util class

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "soundcloud-scraper": "^4.0.0",
     "spotify-url-info": "^2.2.0",
     "youtube-sr": "^2.0.1",
-    "ytdl-core": "^4.0.6"
+    "ytdl-core": "^4.0.6",
+    "ytpl": "^2.0.0-alpha.3"
   },
   "devDependencies": {
     "@discordjs/opus": "^0.3.2",

--- a/src/Player.js
+++ b/src/Player.js
@@ -1,6 +1,7 @@
 const ytdl = require('discord-ytdl-core')
 const Discord = require('discord.js')
 const ytsr = require('youtube-sr')
+const ytpl = require('ytpl')
 const spotify = require('spotify-url-info')
 const soundcloud = require('soundcloud-scraper')
 const moment = require('moment')
@@ -291,9 +292,19 @@ class Player extends EventEmitter {
      * @param {String} query
      */
     async _handlePlaylist (message, query) {
-        const playlist = await ytsr.getPlaylist(query)
+        const playlist = await ytpl(query).catch(() => {})
         if (!playlist) return this.emit('noResults', message, query)
-        playlist.tracks = playlist.videos.map((item) => new Track(item, message.author))
+        playlist.tracks = playlist.items.map((item) => new Track({
+            title: item.title,	
+            description: item.description,	
+            views: item.views,	
+            durationFormatted: item.duration,	
+            url: item.url,	
+            thumbnail: item.thumbnail,	
+            channel: {	
+                name: item.author.name	
+            }	
+        }, message.author))
         playlist.duration = playlist.tracks.reduce((prev, next) => prev + next.duration, 0)
         playlist.thumbnail = playlist.tracks[0].thumbnail
         playlist.requestedBy = message.author

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,8 +1,7 @@
+const ytpl = require('ytpl')
 const ytsr = require('youtube-sr')
 const soundcloud = require('soundcloud-scraper')
-const Discord = require('discord.js')
 
-const youtubeVideoRegex = (/(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/)
 const spotifySongRegex = (/https?:\/\/(?:embed\.|open\.)(?:spotify\.com\/)(?:track\/|\?uri=spotify:track:)((\w|-){22})/)
 
 module.exports = class Util {
@@ -23,10 +22,10 @@ module.exports = class Util {
     }
 
     static isYTPlaylistLink (query) {
-        return ytsr.default.validate(query, "PLAYLIST")
+        return ytpl.validateID(query)
     }
 
     static isYTVideoLink (query) {
-        return youtubeVideoRegex.test(query)
+        return ytsr.default.validate(query, "VIDEO")
     }
 }


### PR DESCRIPTION
This PR changes a few things and revert others.

- Since myself and others were having issues playing youtube playlists I've reverted to ytpl.
- Added PLAYLIST url validation using ytpl, so playlist [links](https://www.youtube.com/watch?v=x8VYWazR5mE&list=PL_A7IF_b8OCR7k9CZovjSoW1Sv99NQYIJ) beggining with a `watch?v=` are still treated as a playlist and not as an individual video.
- Replaced the VIDEO url validation regex with the ytsr validation method.

Hope you approve this PR, contact me if you have any trouble 😄