### PR TITLE
chore: bump ytdl-core and fix warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "soundcloud-scraper": "^4.0.0",
     "spotify-url-info": "^2.2.0",
     "youtube-sr": "^2.0.1",
-    "ytdl-core": "^4.0.6"
+    "ytdl-core": "^4.2.1"
   },
   "devDependencies": {
     "@discordjs/opus": "^0.3.2",

--- a/src/Player.js
+++ b/src/Player.js
@@ -327,13 +327,14 @@ class Player extends EventEmitter {
             trackToPlay = query
         } else if (this.util.isYTVideoLink(query)) {
             const videoData = await ytdl.getBasicInfo(query)
+            const lastThumbnail = videoData.videoDetails.thumbnails.length - 1 /* get the highest quality thumbnail */
             trackToPlay = new Track({
                 title: videoData.videoDetails.title,
                 url: videoData.videoDetails.video_url,
                 views: videoData.videoDetails.viewCount,
-                thumbnail: videoData.videoDetails.thumbnail.thumbnails[0],
+                thumbnail: videoData.videoDetails.thumbnails[lastThumbnail],
                 lengthSeconds: videoData.videoDetails.lengthSeconds,
-                description: videoData.videoDetails.shortDescription,
+                description: videoData.videoDetails.description,
                 author: {
                     name: videoData.videoDetails.author.name
                 }


### PR DESCRIPTION
The PR updates/fixes

- Updates `ytdl-core` to `4.2.1`
- Removes console warnings about `.shortDescription` & `thumbnail.thumbnails`
- Adds best quality possible thumbnail instead of first thumbnail