### PR TITLE
fix: fix incorrect error event docs

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -775,6 +775,6 @@ module.exports = Player
 /**
  * Emitted when an error is triggered
  * @event Player#error
- * @param {Discord.Message} message
  * @param {string} error It can be `NotConnected`, `UnableToJoin` or `NotPlaying`.
+ * @param {Discord.Message} message
  */


### PR DESCRIPTION
This PR fixes:

- Updates `error` event doc to correct typing ([view typing](https://github.com/Androz2091/discord-player/blob/b1c9db39567ae985fbc1ed9c4ce37224d7701e6a/typings/index.d.ts#L82))