### PR TITLE
Small Bug Fix

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -795,10 +795,10 @@ class Player extends EventEmitter {
             if (this.options.leaveOnEnd && !queue.stopped) {
                 setTimeout(() => {
                     queue.voiceConnection.channel.leave()
-                    // Remove the guild from the guilds list
-                    this.queues.delete(queue.guildID)
                 }, this.options.leaveOnEndCooldown || 0)
             }
+            // Remove the guild from the guilds list
+            this.queues.delete(queue.guildID)
             // Emit stop event
             if (queue.stopped) {
                 return this.emit('musicStop')


### PR DESCRIPTION
Fix for:
leaveOnEnd: false,
leaveOnStop: false,
 
when music queue ends, after few minutes when you run play command the song will be added to queue (it needs to play directly but adding to queue?) but not gonna start and if you run skip command you got error