### PR TITLE
:bug: Mistake in filters length

### DIFF
--- a/src/utils/AudioFilters.ts
+++ b/src/utils/AudioFilters.ts
@@ -70,11 +70,11 @@ const FilterList = {
     },
 
     get names() {
-        return Object.keys(this).filter((p) => ['names', 'length'].includes(p) && typeof this[p as FiltersName] !== 'function');
+        return Object.keys(this).filter((p) => !['names', 'length'].includes(p) && typeof this[p as FiltersName] !== 'function');
     },
 
     get length() {
-        return Object.keys(this).filter((p) => ['names', 'length'].includes(p) && typeof this[p as FiltersName] !== 'function').length;
+        return Object.keys(this).filter((p) => !['names', 'length'].includes(p) && typeof this[p as FiltersName] !== 'function').length;
     },
 
     toString() {


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->
Mistake in `AudioFilters.names` and `AudioFilters.length`

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.

> Temporary fix for master: `AudioFilters.length - 2`