### PR TITLE
Fix #584 #585 and #449

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -502,7 +502,7 @@ export class Player extends EventEmitter {
                     author: info.channel.name,
                     url: info.url,
                     thumbnail: lastThumbnail,
-                    duration: Util.buildTimeCode(Util.parseMS(info.duration)),
+                    duration: Util.buildTimeCode(Util.parseMS(info.duration * 1000)),
                     views: parseInt(info.views as unknown as string),
                     requestedBy: message.author,
                     fromPlaylist: false,

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1062,7 +1062,7 @@ export class Player extends EventEmitter {
         if (!queue) return;
 
         if (newState.member.id === this.client.user.id && !newState.channelID) {
-            queue.stream.destroy();
+            if (queue.stream) queue.stream.destroy();
             this.queues.delete(newState.guild.id);
             this.emit(PlayerEvents.BOT_DISCONNECT, queue.firstMessage);
         }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -502,7 +502,7 @@ export class Player extends EventEmitter {
                     author: info.channel.name,
                     url: info.url,
                     thumbnail: lastThumbnail,
-                    duration: Util.buildTimeCode(Util.parseMS(info.duration * 1000)),
+                    duration: Util.buildTimeCode(Util.parseMS(info.duration)),
                     views: parseInt(info.views as unknown as string),
                     requestedBy: message.author,
                     fromPlaylist: false,

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -181,9 +181,10 @@ export class Util {
         const items = Object.keys(data);
         const required = ['days', 'hours', 'minutes', 'seconds'];
 
-        const parsed = items.filter((x) => required.includes(x)).map((m) => (data[m] > 0 ? data[m] : ''));
+        const parsed = items.filter((x) => required.includes(x)).map((m) => data[m]);
+
         const final = parsed
-            .filter((x) => !!x)
+            .slice(parsed.findIndex((x) => x !== 0))
             .map((x) => x.toString().padStart(2, '0'))
             .join(':');
         return final.length <= 3 ? `0:${final.padStart(2, '0') || 0}` : final;


### PR DESCRIPTION
## Changes
This fixes the problem where the internal video duration would be incorrect for direct YouTube links (not searched and retrieved that way) by a factor of 1000.
This fixes the potential fatal crash when a Discord bot would be disconnected (kicked) from a voice channel while in the "MusicStarting" state.

## Status

- [x] These changes have been tested and formatted properly.