### PR TITLE
docs: add trackEnd event

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -307,6 +307,13 @@ export enum QueryType {
  * @param {Track} track The track
  */
 
+/**
+ * Emitted when a track ends
+ * @event Player#trackEnd
+ * @param {Queue} queue The queue
+ * @param {Track} track The track
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface PlayerEvents {
     botDisconnect: (queue: Queue) => any;


### PR DESCRIPTION
## Changes
Adding JSDoc for the Player#trackEnd event. I suspect this also makes it appear in the online documentation, because right now it isn't in there.

## Status

- [x] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.