### PR TITLE
fix(Player): add intents checking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ We are using **[Prettier](https://prettier.io)** to format the code.
 ## Some Rules
 - Use `camelCase` for `Function names`, `Variables`, etc. and `PascalCase` for `Class name`
 - Do not make unused variables/imports
-- Don't forget to write `JSDOC` for each properties and methods
+- Don't forget to write `JSDOC` for each property and method
 - Use English language
 
 # Pull Requests

--- a/docs/migrating/migrating.md
+++ b/docs/migrating/migrating.md
@@ -35,7 +35,7 @@ const queue = player.createQueue(message.guild, {
 });
 ```
 
-The metadata `message` will always be available in every events emitted for that specific `Queue`. You can access it via `queue.metadata`:
+The metadata `message` will always be available in every event emitted for that specific `Queue`. You can access it via `queue.metadata`:
 
 ```js
 player.on("trackStart", (queue, track) => {

--- a/example/music-bot/index.js
+++ b/example/music-bot/index.js
@@ -145,6 +145,10 @@ client.on("messageCreate", async (message) => {
             {
                 name: "bassboost",
                 description: "Toggles bassboost filter"
+            },
+            {
+                name: "ping",
+                description: "Shows bot latency"
             }
         ]);
 
@@ -154,6 +158,24 @@ client.on("messageCreate", async (message) => {
 
 client.on("interactionCreate", async (interaction) => {
     if (!interaction.isCommand() || !interaction.guildId) return;
+
+    if (interaction.commandName === "ping") {
+        await interaction.deferReply();
+        const queue = player.getQueue(interaction.guild);
+
+        return void interaction.followUp({
+            embeds: [
+                {
+                    title: "⏱️ | Latency",
+                    fields: [
+                        { name: "Bot Latency", value: `\`${Math.round(client.ws.ping)}ms\`` },
+                        { name: "Voice Latency", value: !queue ? "N/A" : `UDP: \`${queue.connection.voiceConnection.ping.udp ?? "N/A"}\`ms\nWebSocket: \`${queue.connection.voiceConnection.ping.ws ?? "N/A"}\`ms` }
+                    ],
+                    color: 0xFFFFFF
+                }
+            ]
+        });
+    }
 
     if (!(interaction.member instanceof GuildMember) || !interaction.member.voice.channel) {
         return void interaction.reply({ content: "You are not in a voice channel!", ephemeral: true });

--- a/example/music-bot/index.js
+++ b/example/music-bot/index.js
@@ -1,9 +1,9 @@
 require("dotenv").config();
-const { Client, GuildMember } = require("discord.js");
+const { Client, GuildMember, Intents } = require("discord.js");
 const config = require("./config");
 const { Player, QueryType, QueueRepeatMode } = require("discord-player");
 const client = new Client({
-    intents: ["GUILD_VOICE_STATES", "GUILD_MESSAGES", "GUILDS"]
+    intents: [Intents.FLAGS.GUILD_VOICE_STATES, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILDS]
 });
 
 client.on("ready", () => {

--- a/example/music-bot/package.json
+++ b/example/music-bot/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@discordjs/opus": "^0.5.3",
-    "discord-player": "^5.0.0",
+    "discord-player": "^5.0.1",
     "discord.js": "^13.0.1",
     "dotenv": "^10.0.0"
   }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -46,7 +46,7 @@ class Player extends EventEmitter<PlayerEvents> {
          */
         this.client = client;
 
-        if (new Intents(this.client.options.intents).has(Intents.FLAGS.GUILD_VOICE_STATES)) {
+        if (!(new Intents(this.client.options.intents).has(Intents.FLAGS.GUILD_VOICE_STATES))) {
             throw new PlayerError('client is missing "GUILD_VOICE_STATES" intent');
         }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -516,7 +516,7 @@ class Player extends EventEmitter<PlayerEvents> {
     }
 
     /**
-     * Resolves qeuue
+     * Resolves queue
      * @param {GuildResolvable|Queue} queueLike Queue like object
      * @returns {Queue}
      */

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -46,7 +46,7 @@ class Player extends EventEmitter<PlayerEvents> {
          */
         this.client = client;
 
-        if (!(new Intents(this.client.options.intents).has(Intents.FLAGS.GUILD_VOICE_STATES))) {
+        if (!new Intents(this.client.options.intents).has(Intents.FLAGS.GUILD_VOICE_STATES)) {
             throw new PlayerError('client is missing "GUILD_VOICE_STATES" intent');
         }
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1,4 +1,4 @@
-import { Client, Collection, GuildResolvable, Snowflake, User, VoiceState } from "discord.js";
+import { Client, Collection, GuildResolvable, Snowflake, User, VoiceState, Intents } from "discord.js";
 import { TypedEmitter as EventEmitter } from "tiny-typed-emitter";
 import { Queue } from "./Structures/Queue";
 import { VoiceUtils } from "./VoiceInterface/VoiceUtils";
@@ -45,6 +45,10 @@ class Player extends EventEmitter<PlayerEvents> {
          * @type {Client}
          */
         this.client = client;
+
+        if (new Intents(this.client.options.intents).has(Intents.FLAGS.GUILD_VOICE_STATES)) {
+            throw new PlayerError('client is missing "GUILD_VOICE_STATES" intent');
+        }
 
         /**
          * The extractors collection

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -307,6 +307,13 @@ export enum QueryType {
  * @param {Track} track The track
  */
 
+/**
+ * Emitted when a track ends
+ * @event Player#trackEnd
+ * @param {Queue} queue The queue
+ * @param {Track} track The track
+ */
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export interface PlayerEvents {
     botDisconnect: (queue: Queue) => any;

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,18 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz#118511f316e2e87ee4294761868e254d3da47960"
+  integrity sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@devsnowflake/docgen@devsnowflake/docgen#ts-patch":
   version "0.9.0"
   resolved "https://codeload.github.com/devsnowflake/docgen/tar.gz/cc87c4dfa7136fa1046946eff708bb995ca5e1f7"
@@ -1102,7 +1114,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.1.tgz#95f2d167ffb9b8d2068b0b235302fafd4df711f2"
   integrity sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==
 
-"@tsconfig/node16@^1.0.1":
+"@tsconfig/node16@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.2.tgz#423c77877d0569db20e1fc80885ac4118314010e"
   integrity sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==
@@ -1221,12 +1233,17 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.1.1.tgz#3ddab7f84e4a7e2313f6c414c5b7dac85f4e3ebc"
+  integrity sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==
+
 acorn@^7.1.1, acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.2.4:
+acorn@^8.2.4, acorn@^8.4.1:
   version "8.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.4.1.tgz#56c36251fc7cabc7096adc18f05afe814321a28c"
   integrity sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==
@@ -1566,11 +1583,6 @@ browserslist@^4.16.6:
     electron-to-chromium "^1.3.793"
     escalade "^3.1.1"
     node-releases "^1.1.73"
-
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -4352,14 +4364,6 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
 source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
@@ -4370,7 +4374,7 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -4680,19 +4684,21 @@ ts-mixer@^6.0.0:
   integrity sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==
 
 ts-node@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.1.0.tgz#e656d8ad3b61106938a867f69c39a8ba6efc966e"
-  integrity sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.0.tgz#f1e88249a00e26aa95e9a93c50f70241a8a1c4bb"
+  integrity sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==
   dependencies:
+    "@cspotcode/source-map-support" "0.6.1"
     "@tsconfig/node10" "^1.0.7"
     "@tsconfig/node12" "^1.0.7"
     "@tsconfig/node14" "^1.0.0"
-    "@tsconfig/node16" "^1.0.1"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
-    source-map-support "^0.5.17"
     yn "3.1.1"
 
 tslib@^1.8.1, tslib@^1.9.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,12 +984,12 @@
     node-addon-api "^3.2.1"
 
 "@discordjs/voice@^0.5.5":
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/@discordjs/voice/-/voice-0.5.5.tgz#25dfe4709e5da103875f212f40cf63068abd8850"
-  integrity sha512-i7QSRlPq34UAoTUfxLjlyWJONdrxJ4kZH7F6ZfoDK1rt3AHZv5vFzijBu8bsy040zaYpU3LZQ2MPw/kz1uCr5w==
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@discordjs/voice/-/voice-0.5.6.tgz#78d52567acacab28411fca1dbf8fe3f7b6cc86d3"
+  integrity sha512-CGwD5pz1YB8MXfERcXQ6jVCThfMjzPKbad8pYuvPt4ozFcLWGRKFJ5lj+CSRNDj0Cobc6MIKOKpFfOPlXTKTrw==
   dependencies:
     "@types/ws" "^7.4.4"
-    discord-api-types "^0.19.0"
+    discord-api-types "^0.22.0"
     prism-media "^1.3.1"
     tiny-typed-emitter "^2.0.3"
     ws "^7.4.4"
@@ -2041,11 +2041,6 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-discord-api-types@^0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.19.0.tgz#86ba8021b29190cf860e90a2bc3e29b1d7aab3ba"
-  integrity sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ==
 
 discord-api-types@^0.22.0:
   version "0.22.0"


### PR DESCRIPTION
This update will cause an error to be thrown if the discord client has no `GUILD_VOICE_STATES` intent enabled.

## Changes
- docs: add `trackEnd` event (#674)
- fix(Player): add intents checking (fixes issues like #673)
- chore(example): bump discord-player

## Status
- [x] These changes have been tested and formatted properly.