### PR TITLE
fix(Queue): fix jump

### DIFF
--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -497,10 +497,10 @@ class Queue<T = unknown> {
         const foundTrack = this.remove(track);
         if (!foundTrack) throw new PlayerError("Track not found", ErrorStatusCode.TRACK_NOT_FOUND);
         // since we removed the existing track from the queue,
-        // we now have to place that to position 1
+        // we now have to place that to position 0
         // because we want to jump to that track
-        // this will skip current track and play the next one which will be the foundTrack
-        this.tracks.splice(1, 0, foundTrack);
+        // this will skip current track (not actually in queue) and play the next one which will be the foundTrack
+        this.tracks.splice(0, 0, foundTrack);
 
         return void this.skip();
     }


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->
Fixes jump() method. At some point it was changed from the current track being at position 0 of the queue to being removed when it begins playing and given its own separate `current` property in the Queue. Due to this, the following change was needed to fix the jump() behavior https://github.com/Androz2091/discord-player/commit/8a46d1220a8ce3b003c8c1baf25a40ca3ebec7b3. https://github.com/Androz2091/discord-player/commit/2344265fdaefa42678881341e665e6ca9630e4c0 reverted this fix and it now behaves as described in #683 again.

## Status

- [ x ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.