### PR TITLE
Fixed Shuffle/Jump and enhanced Back

### DIFF
--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -176,6 +176,7 @@ class Queue<T = unknown> {
             this.playing = true;
             if (!this._filtersUpdate && resource?.metadata) this.player.emit("trackStart", this, resource?.metadata ?? this.current);
             this._filtersUpdate = false;
+            this._trackSkipped = false;
         });
 
         this.connection.on("finish", async (resource) => {
@@ -597,8 +598,6 @@ class Queue<T = unknown> {
         if (src && (this.playing || this.tracks.length) && !options.immediate) return this.addTrack(src);
         const track = options.filtersUpdate && !options.immediate ? src || this.current : src ?? this.tracks.shift();
         if (!track) return;
-
-        this._trackSkipped = false;
         this.player.emit("debug", this, "Received play request");
 
         if (!options.filtersUpdate) {

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -420,9 +420,10 @@ class Queue<T = unknown> {
      */
     async back() {
         if (this.#watchDestroyed()) return;
-        const prev = this.previousTracks[this.previousTracks.length - 2]; // because last item is the current track
-        if (!prev) throw new PlayerError("Could not find previous track", ErrorStatusCode.TRACK_NOT_FOUND);
-
+        if (this.previousTracks.length < 2) throw new PlayerError("Could not find previous track", ErrorStatusCode.TRACK_NOT_FOUND);
+        const current = this.previousTracks.pop();
+        const prev = this.previousTracks.pop(); // because last item is the current track
+        this.tracks.unshift(current);
         return await this.play(prev, { immediate: true });
     }
 
@@ -451,14 +452,11 @@ class Queue<T = unknown> {
     shuffle() {
         if (this.#watchDestroyed()) return;
         if (!this.tracks.length || this.tracks.length < 3) return false;
-        const currentTrack = this.tracks.shift();
 
         for (let i = this.tracks.length - 1; i > 0; i--) {
             const j = Math.floor(Math.random() * (i + 1));
             [this.tracks[i], this.tracks[j]] = [this.tracks[j], this.tracks[i]];
         }
-
-        this.tracks.unshift(currentTrack);
 
         return true;
     }
@@ -500,7 +498,7 @@ class Queue<T = unknown> {
         // we now have to place that to position 1
         // because we want to jump to that track
         // this will skip current track and play the next one which will be the foundTrack
-        this.tracks.splice(1, 0, foundTrack);
+        this.tracks.unshift(foundTrack);
 
         return void this.skip();
     }

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -183,7 +183,6 @@ class Queue<T = unknown> {
             this.playing = false;
             if (this._filtersUpdate) return;
             this._streamTime = 0;
-            if (resource && resource.metadata) this.previousTracks.push(resource.metadata);
 
             this.player.emit("trackEnd", this, resource.metadata);
 


### PR DESCRIPTION
## Changes
**Fixed:** jump and shuffle functionality
- Will properly shuffle the first song, and jump to the correct song

**Enhanced:** back functionality to act like traditional playlist.
- No longer has a circular back, when using back current song is added to top of the queue

**Enhanced:** looping track logic to allow tracks to be skipped/jumped.
**Fixed**: currentTrack being added to previousTrack at both the start and end of a song. Now only added at the beginning.