### PR TITLE
Pass ytdlOptions for ytdlGetInfo

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -224,7 +224,7 @@ class Player extends EventEmitter<PlayerEvents> {
         const qt = options.searchEngine === QueryType.AUTO ? QueryResolver.resolve(query) : options.searchEngine;
         switch (qt) {
             case QueryType.YOUTUBE_VIDEO: {
-                const info = await ytdlGetInfo(query).catch(Util.noop);
+                const info = await ytdlGetInfo(query, this.options.ytdlOptions).catch(Util.noop);
                 if (!info) return { playlist: null, tracks: [] };
 
                 const track = new Track(this, {


### PR DESCRIPTION
## Changes
Pass the player's custom `ytdlOptions` to the `ytdlGetInfo` call made by youtube search function. This should fix the unintended behavior difference between the `search` and `play` functions, as `play` function is able to play age restricted videos in EU when a youtube `cookie` is passed as a header, but `search` function is unable to find the video.

See also: https://github.com/Androz2091/discord-player/discussions/687 (I think this is related to it)

## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.