### PR TITLE
Fix _handleVoiceState

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -77,8 +77,17 @@ class Player extends EventEmitter<PlayerEvents> {
         if (!queue) return;
 
         if (oldState.channelId && newState.channelId && oldState.channelId !== newState.channelId) {
-            if (queue?.connection) queue.connection.channel = newState.channel;
-        }
+            if (queue?.connection && newState.member.id === newState.guild.me.id) queue.connection.channel = newState.channel;
+            if (newState.member.id === newState.guild.me.id || newState.member.id !== newState.guild.me.id && oldState.channelId === queue.connection.channel.id) {
+                if (!Util.isVoiceEmpty(queue.connection.channel)) return;
+                const timeout = setTimeout(() => {
+                    if (!Util.isVoiceEmpty(queue.connection.channel)) return;
+                    if (!this.queues.has(queue.guild.id)) return;
+                    if (queue.options.leaveOnEmpty) queue.destroy();
+                    this.emit("channelEmpty", queue);
+                }, queue.options.leaveOnEmptyCooldown || 0).unref();
+                queue._cooldownsTimeout.set(`empty_${oldState.guild.id}`, timeout);
+            }
 
         if (!oldState.channelId && newState.channelId && newState.member.id === newState.guild.me.id) {
             if (newState.serverMute || !newState.serverMute) {
@@ -109,19 +118,23 @@ class Player extends EventEmitter<PlayerEvents> {
             const emptyTimeout = queue._cooldownsTimeout.get(`empty_${oldState.guild.id}`);
             const channelEmpty = Util.isVoiceEmpty(queue.connection.channel);
 
-            if (!channelEmpty && emptyTimeout) {
-                clearTimeout(emptyTimeout);
-                queue._cooldownsTimeout.delete(`empty_${oldState.guild.id}`);
+            if (newState.channelId === queue.connection.channel.id) {
+                if (!channelEmpty && emptyTimeout) {
+                    clearTimeout(emptyTimeout);
+                    queue._cooldownsTimeout.delete(`empty_${oldState.guild.id}`);
+                }
             }
         } else {
-            if (!Util.isVoiceEmpty(queue.connection.channel)) return;
-            const timeout = setTimeout(() => {
+            if (oldState.channelId === queue.connection.channel.id) {
                 if (!Util.isVoiceEmpty(queue.connection.channel)) return;
-                if (!this.queues.has(queue.guild.id)) return;
-                if (queue.options.leaveOnEmpty) queue.destroy();
-                this.emit("channelEmpty", queue);
-            }, queue.options.leaveOnEmptyCooldown || 0).unref();
-            queue._cooldownsTimeout.set(`empty_${oldState.guild.id}`, timeout);
+                const timeout = setTimeout(() => {
+                    if (!Util.isVoiceEmpty(queue.connection.channel)) return;
+                    if (!this.queues.has(queue.guild.id)) return;
+                    if (queue.options.leaveOnEmpty) queue.destroy();
+                    this.emit("channelEmpty", queue);
+                }, queue.options.leaveOnEmptyCooldown || 0).unref();
+                queue._cooldownsTimeout.set(`empty_${oldState.guild.id}`, timeout);
+            }
         }
     }
 


### PR DESCRIPTION
connection.channel rapidly changing in a large server with a busy voicestate, it shud never change.
fix: it shud only change the connection.channel when the bot being moved somewhere else.
also fixing how it handles voice move so it triggers channelEmpty correctly, on member move from connection.channel and bot move to an empty channel.
last thing is limiting the join and leave to the connection.channel only

## Changes
<!-- describe what changes this PR includes and explain why are they needed -->

## Status

- [ Y ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.