### PR TITLE
fix Jump(), executing as intended

### DIFF
--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -493,14 +493,9 @@ class Queue<T = unknown> {
      */
     jump(track: Track | number): void {
         if (this.#watchDestroyed()) return;
-        // remove the track if exists
         const foundTrack = this.remove(track);
         if (!foundTrack) throw new PlayerError("Track not found", ErrorStatusCode.TRACK_NOT_FOUND);
-        // since we removed the existing track from the queue,
-        // we now have to place that to position 1
-        // because we want to jump to that track
-        // this will skip current track and play the next one which will be the foundTrack
-        this.tracks.splice(1, 0, foundTrack);
+        this.tracks.splice(0, 0, foundTrack);
 
         return void this.skip();
     }


### PR DESCRIPTION
## Changes
The previous change made the track 1 step forward in the queue list.
The placing of the selected song must be without offset, otherwhise the next song that will be played will be the actual next song in the queue, and then, only after that, the song that was selected in the Jump() function.

Regardless of the "delete" portion, as the splice() is done after it.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.