### PR TITLE
add Dodong to list of example bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ You just need to install it using `npm i --save @discord-player/extractor` (disc
 These bots are made by the community, they can help you build your own!
 
 * **[Discord Music Bot](https://github.com/Androz2091/discord-music-bot)** by [Androz2091](https://github.com/Androz2091)
+* [Dodong](https://github.com/nizeic/Dodong) by [nizeic](https://github.com/nizeic)
 * [Musico](https://github.com/Whirl21/Musico) by [Whirl21](https://github.com/Whirl21)
 * [Music-bot](https://github.com/ZerioDev/Music-bot) by [ZerioDev](https://github.com/ZerioDev)
 * [AtlantaBot](https://github.com/Androz2091/AtlantaBot) by [Androz2091](https://github.com/Androz2091) (**outdated**)


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->
this adds the [Dodong music bot](https://github.com/nizeic/Dodong) (uses discord.js v13 & discord-player@dev) to the list of example bots in the readme
## Status

- [x] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.