### PR TITLE
botDisconnect not working (Hot FIX)

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -77,7 +77,7 @@ class Player extends EventEmitter<PlayerEvents> {
         const queue = this.getQueue(oldState.guild.id);
         if (!queue) return;
 
-        if (oldState.channelId && !newState.channelId && oldState.channelId !== newState.channelId) {
+        if (oldState.channelId && newState && oldState.channelId !== newState.channelId) {
             if (queue?.connection && newState.member.id === newState.guild.me.id) queue.connection.channel = newState.channel;
             if (queue.connection.channel && newState.member.id === newState.guild.me.id || (newState.member.id !== newState.guild.me.id && oldState.channelId === queue.connection.channel?.id)) {
                 if (!Util.isVoiceEmpty(queue.connection.channel)) return;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -79,7 +79,7 @@ class Player extends EventEmitter<PlayerEvents> {
 
         if (oldState.channelId && !newState.channelId && oldState.channelId !== newState.channelId) {
             if (queue?.connection && newState.member.id === newState.guild.me.id) queue.connection.channel = newState.channel;
-            if (newState.member.id === newState.guild.me.id || (newState.member.id !== newState.guild.me.id && oldState.channelId === queue.connection.channel.id)) {
+            if (queue.connection.channel && newState.member.id === newState.guild.me.id || (newState.member.id !== newState.guild.me.id && oldState.channelId === queue.connection.channel?.id)) {
                 if (!Util.isVoiceEmpty(queue.connection.channel)) return;
                 const timeout = setTimeout(() => {
                     if (!Util.isVoiceEmpty(queue.connection.channel)) return;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -77,7 +77,7 @@ class Player extends EventEmitter<PlayerEvents> {
         const queue = this.getQueue(oldState.guild.id);
         if (!queue) return;
 
-        if (oldState.channelId && newState.channelId && oldState.channelId !== newState.channelId) {
+        if (oldState.channelId && !newState.channelId && oldState.channelId !== newState.channelId) {
             if (queue?.connection && newState.member.id === newState.guild.me.id) queue.connection.channel = newState.channel;
             if (newState.member.id === newState.guild.me.id || (newState.member.id !== newState.guild.me.id && oldState.channelId === queue.connection.channel.id)) {
                 if (!Util.isVoiceEmpty(queue.connection.channel)) return;
@@ -109,6 +109,7 @@ class Player extends EventEmitter<PlayerEvents> {
             }
 
             if (oldState.member.id === this.client.user.id && !newState.channelId) {
+                queue.connection.channel = oldState.channel;
                 queue.destroy();
                 return void this.emit("botDisconnect", queue);
             }


### PR DESCRIPTION
it's an hot fix for this issue https://github.com/Androz2091/discord-player/issues/972

## Changes
It's an hotfix for botDisconnected event because this event is never called

I check if `newState` and no `newState.channelId`
I add `queue.connection.channel &&` to check if the channel connection for newStats exist
I set the queue.connection.channel with the of state in the botDisconnect statement for get the channel where it was disconnected

## Remains to be repaired
- [ ] If the bot change the voice channel (move) the `trackStart` event is emmited but the track continues where it was
- [ ] While `queue.connection.disconnect()` is called the events `queueEnd`, `botDisconnect` is called, I think it would be better to call a single `botDisconnect` event not `queueEnd` even
## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.