### PR TITLE
fix: "Cannot use destroyed queue" error when calling queue.destroy()

### DIFF
--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -220,11 +220,11 @@ class Queue<T = unknown> {
      */
     destroy(disconnect = this.options.leaveOnStop) {
         if (this.#watchDestroyed()) return;
+        this.#destroyed = true;
         if (this.connection) this.connection.end();
         if (disconnect) this.connection?.disconnect();
         this.player.queues.delete(this.guild.id);
         this.player.voiceUtils.cache.delete(this.guild.id);
-        this.#destroyed = true;
     }
 
     /**


### PR DESCRIPTION
## Changes
When calling `queue.destroy()` property `this.#destroyed` is set to `true` before connection is ended/destroyed to fix its value in `this.connection.on("finish")` listener.

closes #1106 

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.