### PR TITLE
fixed current track to not add twice to previousTracks (#910)

### DIFF
--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -613,7 +613,7 @@ class Queue<T = unknown> {
         if (this.#watchDestroyed()) return;
         const length = typeof options.length === "number" ? (options.length <= 0 || options.length === Infinity ? 15 : options.length) : 15;
 
-        const index = Math.round((this.streamTime / this.current.durationMS) * length);
+        const index = Math.floor((this.streamTime / this.current.durationMS) * length);
         const indicator = typeof options.indicator === "string" && options.indicator.length > 0 ? options.indicator : "🔘";
         const line = typeof options.line === "string" && options.line.length > 0 ? options.line : "▬";
 

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -210,10 +210,10 @@ class Queue<T = unknown> {
             if (!this.tracks.length && this.repeatMode === QueueRepeatMode.OFF) {
                 this.emitEnd();
             } else if (!this.tracks.length && this.repeatMode === QueueRepeatMode.AUTOPLAY) {
-                this._handleAutoplay(Util.last(this.previousTracks));
+                this._handleAutoplay(this.current);
             } else {
-                if (this.repeatMode === QueueRepeatMode.TRACK) return void this.play(Util.last(this.previousTracks), { immediate: true });
-                if (this.repeatMode === QueueRepeatMode.QUEUE) this.tracks.push(Util.last(this.previousTracks));
+                if (this.repeatMode === QueueRepeatMode.TRACK) return void this.play(this.current, { immediate: true });
+                if (this.repeatMode === QueueRepeatMode.QUEUE) this.tracks.push(this.current);
                 const nextTrack = this.tracks.shift();
                 this.play(nextTrack, { immediate: true });
                 return;
@@ -458,7 +458,7 @@ class Queue<T = unknown> {
      */
     async back() {
         if (this.#watchDestroyed()) return;
-        const prev = this.previousTracks[this.previousTracks.length - 2]; // because last item is the current track
+        const prev = this.previousTracks[this.previousTracks.length - 1];
         if (!prev) throw new PlayerError("Could not find previous track", ErrorStatusCode.TRACK_NOT_FOUND);
 
         return await this.play(prev, { immediate: true });
@@ -695,10 +695,7 @@ class Queue<T = unknown> {
 
         this.player.emit("debug", this, "Received play request");
 
-        if (!options.filtersUpdate) {
-            this.previousTracks = this.previousTracks.filter((x) => x.id !== track.id);
-            this.previousTracks.push(track);
-        }
+        if (!options.filtersUpdate) this.previousTracks = this.previousTracks.filter((x) => x.id !== track.id);
 
         let stream = null;
         const hasCustomDownloader = typeof this.onBeforeCreateStream === "function";


### PR DESCRIPTION
## Changes
This PR fixes that current track to not add twice to previousTracks (#910). 

The current track was being added to previousTracks twice, once at [the track start](https://github.com/Androz2091/discord-player/blob/646f50b3025850d64eb0cf80e98ce33946dfa253/src/Structures/Queue.ts#L700) and once at [the track end](https://github.com/Androz2091/discord-player/blob/646f50b3025850d64eb0cf80e98ce33946dfa253/src/Structures/Queue.ts#L206), so that tracks in previousTracks were always duplicated.
Therefore, I made a change so that previousTracks does not store the current track.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.