### PR TITLE
feat: implement Lavalink compatible equalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ yarn*.log
 
 dev/
 packages/
+
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://discord-player.js.org",
   "dependencies": {
-    "@discord-player/equalizer": "^0.1.1",
+    "@discord-player/equalizer": "^0.1.2",
     "@discordjs/voice": "^0.11.0",
     "libsodium-wrappers": "^0.7.10",
     "tiny-typed-emitter": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "homepage": "https://discord-player.js.org",
   "dependencies": {
+    "@discord-player/equalizer": "^0.1.0",
     "@discordjs/voice": "^0.11.0",
     "libsodium-wrappers": "^0.7.10",
     "tiny-typed-emitter": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://discord-player.js.org",
   "dependencies": {
-    "@discord-player/equalizer": "^0.1.0",
+    "@discord-player/equalizer": "^0.1.1",
     "@discordjs/voice": "^0.11.0",
     "libsodium-wrappers": "^0.7.10",
     "tiny-typed-emitter": "^2.1.0",

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -14,7 +14,7 @@ import { VolumeTransformer } from "../VoiceInterface/VolumeTransformer";
 import { createFFmpegStream } from "../utils/FFmpegStream";
 import os from "os";
 import { parentPort } from "worker_threads";
-import type { EqualizerFilter } from "@discord-player/equalizer";
+import type { EqualizerStream } from "@discord-player/equalizer";
 
 class Queue<T = unknown> {
     public readonly guild: Guild;
@@ -124,9 +124,9 @@ class Queue<T = unknown> {
 
     /**
      * Equalizer for this player
-     * @type {EqualizerFilter.EqualizerStream}
+     * @type {EqualizerStream}
      */
-    public get equalizer() {
+    public get equalizer(): EqualizerStream | null {
         return this.connection.equalizer;
     }
 
@@ -754,7 +754,8 @@ class Queue<T = unknown> {
         const resource: AudioResource<Track> = this.connection.createStream(ffmpegStream, {
             type: StreamType.Raw,
             data: track,
-            disableVolume: Boolean(this.options.disableVolume)
+            disableVolume: Boolean(this.options.disableVolume),
+            disableEqualizer: Boolean(this.options.disableEqualizer)
         });
 
         if (options.seek) this._streamTime = options.seek;

--- a/src/Structures/Queue.ts
+++ b/src/Structures/Queue.ts
@@ -14,6 +14,7 @@ import { VolumeTransformer } from "../VoiceInterface/VolumeTransformer";
 import { createFFmpegStream } from "../utils/FFmpegStream";
 import os from "os";
 import { parentPort } from "worker_threads";
+import type { EqualizerFilter } from "@discord-player/equalizer";
 
 class Queue<T = unknown> {
     public readonly guild: Guild;
@@ -119,6 +120,14 @@ class Queue<T = unknown> {
         if ("onBeforeCreateStream" in this.options) this.onBeforeCreateStream = this.options.onBeforeCreateStream;
 
         this.player.emit("debug", this, `Queue initialized:\n\n${this.player.scanDeps()}`);
+    }
+
+    /**
+     * Equalizer for this player
+     * @type {EqualizerFilter.EqualizerStream}
+     */
+    public get equalizer() {
+        return this.connection.equalizer;
     }
 
     /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -137,6 +137,7 @@ export interface PlayerProgressbarOptions {
  * @property {number} [bufferingTimeout=3000] Buffering timeout for the stream
  * @property {boolean} [spotifyBridge=true] If player should bridge spotify source to youtube
  * @property {boolean} [disableVolume=false] If player should disable inline volume
+ * @property {boolean} [disableEqualizer=false] If player should disable equalizer
  * @property {number} [volumeSmoothness=0] The volume transition smoothness between volume changes (lower the value to get better result)
  * Setting this or leaving this empty will disable this effect. Example: `volumeSmoothness: 0.1`
  * @property {Function} [onBeforeCreateStream] Runs before creating stream
@@ -153,6 +154,7 @@ export interface PlayerOptions {
     bufferingTimeout?: number;
     spotifyBridge?: boolean;
     disableVolume?: boolean;
+    disableEqualizer?: boolean;
     volumeSmoothness?: number;
     onBeforeCreateStream?: (track: Track, source: TrackSource, queue: Queue) => Promise<Readable>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@discord-player/equalizer@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@discord-player/equalizer/-/equalizer-0.1.0.tgz#113629b41a5704be7b1f0c5e9f1b113e6c2d1616"
-  integrity sha512-udlW5UUcrDf5IOEjiK4u9uGeCvAcuz6XiuEKfTwvmMBzjbScr/4eMoE6sbvSDIcUqLUmjG90OZJ/jj9SBMcCZA==
+"@discord-player/equalizer@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@discord-player/equalizer/-/equalizer-0.1.1.tgz#432336b5093afed3a53d8ed6429864c75bbd5145"
+  integrity sha512-mBWixcE3mjmEjgszQ431cJB6IbgMZ7lXvS3BQrvtw/GKfD7a4M6WFiVl1AVrz/nt+bXp5JNcqYu5VRYmB80Uvg==
 
 "@discordjs/builders@^1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,6 +30,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@discord-player/equalizer@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@discord-player/equalizer/-/equalizer-0.1.0.tgz#113629b41a5704be7b1f0c5e9f1b113e6c2d1616"
+  integrity sha512-udlW5UUcrDf5IOEjiK4u9uGeCvAcuz6XiuEKfTwvmMBzjbScr/4eMoE6sbvSDIcUqLUmjG90OZJ/jj9SBMcCZA==
+
 "@discordjs/builders@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-1.1.0.tgz#4366a4fe069238c3e6e674b74404c79f3ba76525"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@discord-player/equalizer@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@discord-player/equalizer/-/equalizer-0.1.1.tgz#432336b5093afed3a53d8ed6429864c75bbd5145"
-  integrity sha512-mBWixcE3mjmEjgszQ431cJB6IbgMZ7lXvS3BQrvtw/GKfD7a4M6WFiVl1AVrz/nt+bXp5JNcqYu5VRYmB80Uvg==
+"@discord-player/equalizer@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@discord-player/equalizer/-/equalizer-0.1.2.tgz#df37c07077671c9a109783c90265fd8ffe8e3084"
+  integrity sha512-OHhQ1CA8N+L3zvax4bkSiRoZ8AY4s3KoPXdHHBDNNdaH8XEDsnSlcrlEQZgnMnEyoWS4BzUWGRcVPaDySmt6fA==
 
 "@discordjs/builders@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Changes

This PR implements Lavalink/Lavaplayer compatible 15 band equalizer to discord-player using [@discord-player/equalizer](https://npm.im/@discord-player/equalizer) library.

## Proposed API

Equalizer can be accessed with `queue.equalizer` which may be `EqualizerStream` instance or `null`. Just like inline volume, equalizer can be disabled by passing `disableEqualizer: true` to `createQueue`.

```js
if (!queue.equalizer) return message.reply("Equalizer is not available");

const bands = [
    { band: 0, gain: 0.25 },
    { band: 1, gain: 0.25 },
    { band: 2, gain: 0.25 },
];

// apply config
queue.equalizer.setEQ(bands);

// toggle equalizer on/off
queue.equalizer.toggle();
queue.equalizer.enable();
queue.equalizer.disable();

// get equalizer state
queue.equalizer.getEQ();

// reset equalizer
queue.equalizer.reset();
```

## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.