### PR TITLE
feat(Queue): add trackUpdate event

### DIFF
--- a/packages/discord-player/src/Structures/Queue.ts
+++ b/packages/discord-player/src/Structures/Queue.ts
@@ -397,7 +397,12 @@ class Queue<T = unknown> {
         this.connection.on('start', (resource) => {
             if (this.#watchDestroyed(false)) return;
             this.playing = true;
-            if (!this._filtersUpdate) this.player.emit('trackStart', this, resource?.metadata ?? this.current);
+
+            if (!this._filtersUpdate) {
+                this.player.emit('trackStart', this, resource?.metadata ?? this.current);
+            } else {
+                this.player.emit('trackUpdate', this, resource?.metadata ?? this.current);
+            }
             this._filtersUpdate = false;
         });
 

--- a/packages/discord-player/src/types/types.ts
+++ b/packages/discord-player/src/types/types.ts
@@ -334,6 +334,13 @@ export enum QueryType {
  */
 
 /**
+ * Emitted when a track is updated
+ * @event Player#trackUpdate
+ * @param {Queue} queue The queue
+ * @param {Track} track The track
+ */
+
+/**
  * Emitted when a track ends
  * @event Player#trackEnd
  * @param {Queue} queue The queue
@@ -360,6 +367,7 @@ export interface PlayerEvents {
     trackAdd: (queue: Queue, track: Track) => any;
     tracksAdd: (queue: Queue, track: Track[]) => any;
     trackStart: (queue: Queue, track: Track) => any;
+    trackUpdate: (queue: Queue, track: Track) => any;
     trackEnd: (queue: Queue, track: Track) => any;
     voiceStateUpdate: (queue: Queue, oldState: VoiceState, newState: VoiceState) => any;
 }


### PR DESCRIPTION
## Changes
We have a `trackStart` event that is intentionally emitted only when `filtersUpdate` is false.
Currently, there is no event for cases when `filtersUpdate` is set to true, for example, when we call `seek()`. 
This PR adds `trackUpdate` event to handle that.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.