### PR TITLE
feat(QueryResolver): apple music user playlists

### DIFF
--- a/packages/discord-player/src/utils/QueryResolver.ts
+++ b/packages/discord-player/src/utils/QueryResolver.ts
@@ -12,7 +12,7 @@ const vimeoRegex = /^(http|https)?:\/\/(www\.|player\.)?vimeo\.com\/(?:channels\
 const reverbnationRegex = /^https:\/\/(www.)?reverbnation.com\/(.+)\/song\/(.+)$/;
 const attachmentRegex = /^https?:\/\/.+$/;
 const appleMusicSongRegex = /^https?:\/\/music\.apple\.com\/.+?\/(song|album)\/.+?(\/.+?\?i=|\/)([0-9]+)$/;
-const appleMusicPlaylistRegex = /^https?:\/\/music\.apple\.com\/.+?\/playlist\/.+\/pl\.[a-f0-9]+$/;
+const appleMusicPlaylistRegex = /^https?:\/\/music\.apple\.com\/.+?\/playlist\/.+\/pl\.(u-)?[a-zA-Z0-9]+$/;
 const appleMusicAlbumRegex = /^https?:\/\/music\.apple\.com\/.+?\/album\/.+\/([0-9]+)$/;
 // #endregion scary things above *sigh*
 


### PR DESCRIPTION
## Changes
Changed the regex variable to be able to recognize user-created apple music playlists. 

User playlists on Apple Music have `u-` appended after `pl.` in the URL. The ids also contain uppercase and lowercase characters from a-z.

tested and working properly. functions the same as a normal Apple Music playlist would.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.