### PR TITLE
feat(GuildQueue): add size getter

### DIFF
--- a/packages/discord-player/src/Structures/GuildQueue.ts
+++ b/packages/discord-player/src/Structures/GuildQueue.ts
@@ -309,6 +309,17 @@ export class GuildQueue<Meta = unknown> {
         this.repeatMode = mode;
     }
 
+	/**
+	 * Gets the size of the queue
+	 */
+	public get size() {
+		return this.tracks.size;
+	}
+	
+	public getSize() {
+		return this.size;
+	}
+
     /**
      * Check if this queue has no tracks left in it
      */

--- a/packages/discord-player/src/Structures/GuildQueueHistory.ts
+++ b/packages/discord-player/src/Structures/GuildQueueHistory.ts
@@ -35,6 +35,17 @@ export class GuildQueueHistory<Meta = unknown> {
         return this.queue.options.disableHistory;
     }
 
+	/**
+	 * Gets the size of the queue
+	 */
+	public get size() {
+		return this.tracks.size;
+	}
+		
+	public getSize() {
+		return this.size;
+	}
+
     /**
      * If history is empty
      */


### PR DESCRIPTION
## Changes
Added getSize method / size property to the GuildQueue and GuildQueueHistory to have consistency when using queue (similar to queue.isEmpty())

## Status

- [x] These changes are backwards compatible. 