### PR TITLE
Fix declaration file not found

### DIFF
--- a/packages/discord-player/package.json
+++ b/packages/discord-player/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
     },
     "./src/*": "./dist/*",
     "./dist/*": "./dist/*"


### PR DESCRIPTION
## Changes
This will fix **Could not find declaration file for module 'discord-player'** when using typescript with module resolution set to Node16 or NodeNext.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.