### PR TITLE
feat: implement custom ffmpeg stream

### DIFF
--- a/examples/karasu/yarn.lock
+++ b/examples/karasu/yarn.lock
@@ -33,20 +33,6 @@ __metadata:
   languageName: node
   linkType: soft
 
-"@discordjs/builders@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@discordjs/builders@npm:1.4.0"
-  dependencies:
-    "@discordjs/util": ^0.1.0
-    "@sapphire/shapeshift": ^3.7.1
-    discord-api-types: ^0.37.20
-    fast-deep-equal: ^3.1.3
-    ts-mixer: ^6.0.2
-    tslib: ^2.4.1
-  checksum: 3089ea5dc58e62c0314fd5fd995281d183d1a938d14a71b89c47b71b6cdf4cdf9f8c2ee1d04ca59e6bdde583b8bb785f3b53d917fb155cade8d27ac0dedbc942
-  languageName: node
-  linkType: hard
-
 "@discordjs/builders@npm:^1.5.0":
   version: 1.5.0
   resolution: "@discordjs/builders@npm:1.5.0"
@@ -62,10 +48,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discordjs/collection@npm:^1.1.0, @discordjs/collection@npm:^1.2.0, @discordjs/collection@npm:^1.3.0":
+"@discordjs/builders@npm:^1.6.0":
+  version: 1.6.1
+  resolution: "@discordjs/builders@npm:1.6.1"
+  dependencies:
+    "@discordjs/formatters": ^0.3.0
+    "@discordjs/util": ^0.2.0
+    "@sapphire/shapeshift": ^3.8.1
+    discord-api-types: ^0.37.37
+    fast-deep-equal: ^3.1.3
+    ts-mixer: ^6.0.3
+    tslib: ^2.5.0
+  checksum: 057b5585d17e6273d99aa4cb356ca845d54785d95c0af05418f30eb933cf0b80043f7941effe7a593142c6817f47b893c5a973dfd95f3db24e0570666781e2d9
+  languageName: node
+  linkType: hard
+
+"@discordjs/collection@npm:^1.1.0, @discordjs/collection@npm:^1.2.0":
   version: 1.3.0
   resolution: "@discordjs/collection@npm:1.3.0"
   checksum: 5ca6e9757f4c1e19564a0ac96ebfcabd1a83bf3ac0270034a0ea887f418f196caea4b54ebac5aaf0fc28d98f58f12794a6242d07acf08c946f23aa2e0047e87d
+  languageName: node
+  linkType: hard
+
+"@discordjs/collection@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@discordjs/collection@npm:1.5.0"
+  checksum: 072043743c5e5ef99033f1c227fd92f437a0665b8f0a5bfa26bacc6610963d03b54c45da0e0116ce30e4612efc52b2db0a0827f79091a135409237722db5400a
   languageName: node
   linkType: hard
 
@@ -75,6 +83,15 @@ __metadata:
   dependencies:
     discord-api-types: ^0.37.35
   checksum: cc721d1904501910288b48ae4c20df5fb1beff78f2463f780463f7fa7efe661bb739e324fb9e8b2c09aded3ce7cfcc2f58cd3793c0d61da96f87c50f666bf998
+  languageName: node
+  linkType: hard
+
+"@discordjs/formatters@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@discordjs/formatters@npm:0.3.0"
+  dependencies:
+    discord-api-types: ^0.37.37
+  checksum: cdf0d842f268a1b8c072522f58b0c77853e825964acb1e3b189f53d740d0d4ee4ed3b4be177ce4ab30a665bc1e6953348ab0d29b5fd52a0651e74eb63ad4be6d
   languageName: node
   linkType: hard
 
@@ -107,26 +124,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discordjs/rest@npm:^1.4.0":
-  version: 1.5.0
-  resolution: "@discordjs/rest@npm:1.5.0"
+"@discordjs/rest@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@discordjs/rest@npm:1.7.0"
   dependencies:
-    "@discordjs/collection": ^1.3.0
-    "@discordjs/util": ^0.1.0
+    "@discordjs/collection": ^1.5.0
+    "@discordjs/util": ^0.2.0
     "@sapphire/async-queue": ^1.5.0
-    "@sapphire/snowflake": ^3.2.2
-    discord-api-types: ^0.37.23
-    file-type: ^18.0.0
-    tslib: ^2.4.1
-    undici: ^5.13.0
-  checksum: 98b3a97fa3dbecd406cefca5e5245d51a1ab9eb748001f9d128065cc6dd6f61cc23efbdfa11e84e5147131fe40239d23c37b503d8c4c1a40b10d67b4c5b255ef
-  languageName: node
-  linkType: hard
-
-"@discordjs/util@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@discordjs/util@npm:0.1.0"
-  checksum: 880e15cd761437a21cf17b8a9dab50e7e5418fcc77dc34037c31a52b871fab1b958218ab6218aafd20af8b7a4e658a705d3f257268324773a285d9a06368c1b9
+    "@sapphire/snowflake": ^3.4.0
+    discord-api-types: ^0.37.37
+    file-type: ^18.2.1
+    tslib: ^2.5.0
+    undici: ^5.21.0
+  checksum: 5d52ae02b77abafbcd70c650a9760625a7afab37875a7fc85404e1053e12745aeca819747ad4dbbaab78b1df0a33a050b980b1e91ba356c496bb0ea93d32e10f
   languageName: node
   linkType: hard
 
@@ -516,7 +526,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/shapeshift@npm:^3.7.1, @sapphire/shapeshift@npm:^3.8.1":
+"@sapphire/shapeshift@npm:^3.8.1":
   version: 3.8.1
   resolution: "@sapphire/shapeshift@npm:3.8.1"
   dependencies:
@@ -526,10 +536,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/snowflake@npm:^3.2.2":
-  version: 3.4.0
-  resolution: "@sapphire/snowflake@npm:3.4.0"
-  checksum: 556b7001f33d6edbbbcbca46f6abfa56c732a29e78b693161e358688e688edcb012d2c1bc944e7ffb41bd6c9950d261bc73f95656dc01643361a218b4f5ab985
+"@sapphire/snowflake@npm:^3.4.0":
+  version: 3.4.2
+  resolution: "@sapphire/snowflake@npm:3.4.2"
+  checksum: 3bcd05608a63f012538aa0a45bc6abe5b19e15979a1012a9b3af1e0901f897e4df83c80d484c87bd1dece1124f5a14a2f86427190b1dca7f116ee34f13c96788
   languageName: node
   linkType: hard
 
@@ -1362,7 +1372,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"discord-api-types@npm:^0.37.20, discord-api-types@npm:^0.37.23":
+"discord-api-types@npm:^0.37.20":
   version: 0.37.33
   resolution: "discord-api-types@npm:0.37.33"
   checksum: d1e31106081ef79d3ea721b8991c5de155879e6d01c47a025b2c41e0496b551608e72e383caf23680938219099b6c3bd43cbacf48edeb7fc9a3c1730c1811ba8
@@ -1398,23 +1408,24 @@ __metadata:
   languageName: node
   linkType: soft
 
-"discord.js@npm:^14.7.1":
-  version: 14.7.1
-  resolution: "discord.js@npm:14.7.1"
+"discord.js@npm:^14.9.0":
+  version: 14.9.0
+  resolution: "discord.js@npm:14.9.0"
   dependencies:
-    "@discordjs/builders": ^1.4.0
-    "@discordjs/collection": ^1.3.0
-    "@discordjs/rest": ^1.4.0
-    "@discordjs/util": ^0.1.0
-    "@sapphire/snowflake": ^3.2.2
-    "@types/ws": ^8.5.3
-    discord-api-types: ^0.37.20
+    "@discordjs/builders": ^1.6.0
+    "@discordjs/collection": ^1.5.0
+    "@discordjs/formatters": ^0.3.0
+    "@discordjs/rest": ^1.7.0
+    "@discordjs/util": ^0.2.0
+    "@sapphire/snowflake": ^3.4.0
+    "@types/ws": ^8.5.4
+    discord-api-types: ^0.37.37
     fast-deep-equal: ^3.1.3
     lodash.snakecase: ^4.1.1
-    tslib: ^2.4.1
-    undici: ^5.13.0
-    ws: ^8.11.0
-  checksum: fa861275b1f5360ef1b06cd514014ebd4e3f384655834dd1f73fd9f715bee643500f9d837c52f496d306825bc9c3d6c94e67463d91326e3750a28db765926ad6
+    tslib: ^2.5.0
+    undici: ^5.21.0
+    ws: ^8.13.0
+  checksum: 34589830f771b238975cbabb82531db78756b1b132b6b296ad845bc93755cfee34e65febb638e1b77e9e68d9ce2362cd4d4057123c37909e1354d670b747cb71
   languageName: node
   linkType: hard
 
@@ -1822,14 +1833,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:^18.0.0":
-  version: 18.2.0
-  resolution: "file-type@npm:18.2.0"
+"file-type@npm:^18.2.1":
+  version: 18.2.1
+  resolution: "file-type@npm:18.2.1"
   dependencies:
     readable-web-to-node-stream: ^3.0.2
     strtok3: ^7.0.0
     token-types: ^5.0.1
-  checksum: 6bbb072fb03eee8c3a8ad6bbaa97a81051abaf31f372e42a634dffaec319ae57de06ea632ee47d80c34a501bb1068892a8f8dc2cbcc5efd127784d38f0377712
+  checksum: bbc9381292e96a72ecd892f9f5e1a9a8d3f9717955841346e55891acfe099135bfa149f7dad51f35ee52b5e7e0a1a02d7375061b2800758011682c2e9d96953e
   languageName: node
   linkType: hard
 
@@ -2628,7 +2639,7 @@ __metadata:
     colorette: ^2.0.19
     discord-api-types: ^0.37.35
     discord-player: latest
-    discord.js: ^14.7.1
+    discord.js: ^14.9.0
     npm-run-all: ^4.1.5
     opusscript: ^0.0.8
     play-dl: ^1.9.6
@@ -4293,7 +4304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-mixer@npm:^6.0.2, ts-mixer@npm:^6.0.3":
+"ts-mixer@npm:^6.0.3":
   version: 6.0.3
   resolution: "ts-mixer@npm:6.0.3"
   checksum: 7fbaba0a413bf817835a6a23d46bccf4192dd4d7345b6bae9d594c88acffac35bf4995ef3cce753090c8abcdf2afd16dba8899365584a1f960ccc2a15bf2e2d6
@@ -4402,21 +4413,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.13.0, undici@npm:^5.8.2":
-  version: 5.18.0
-  resolution: "undici@npm:5.18.0"
-  dependencies:
-    busboy: ^1.6.0
-  checksum: 74e0f357c376c745fcca612481a5742866ae36086ad387e626255f4c4a15fc5357d9d0fa4355271b6a633d50f5556c3e85720844680c44861c66e23afca7245f
-  languageName: node
-  linkType: hard
-
 "undici@npm:^5.20.0":
   version: 5.21.0
   resolution: "undici@npm:5.21.0"
   dependencies:
     busboy: ^1.6.0
   checksum: 013d5fd503b631d607942c511c2ab3f3fa78ebcab302acab998b43176b4815503ec15ed9752c5a47918b3bff8a0137768001d3eb57625b2bb6f6d30d8a794d6c
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.21.0":
+  version: 5.22.0
+  resolution: "undici@npm:5.22.0"
+  dependencies:
+    busboy: ^1.6.0
+  checksum: 8dc55240a60ae7680798df344e8f46ad0f872ed0fa434fb94cc4fd2b5b2f8053bdf11994d15902999d3880f9bf7cd875a2e90883d2702bf0f366dacd9cbf3fc6
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.8.2":
+  version: 5.18.0
+  resolution: "undici@npm:5.18.0"
+  dependencies:
+    busboy: ^1.6.0
+  checksum: 74e0f357c376c745fcca612481a5742866ae36086ad387e626255f4c4a15fc5357d9d0fa4355271b6a633d50f5556c3e85720844680c44861c66e23afca7245f
   languageName: node
   linkType: hard
 

--- a/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
+++ b/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
@@ -158,6 +158,11 @@ export class ExtractorExecutionContext extends PlayerEventsEmitter<ExtractorExec
     public async run<T = unknown>(fn: ExtractorExecutionFN<T>, filterBlocked = true) {
         const blocked = this.player.options.blockExtractors ?? [];
 
+        if (!this.store.size) {
+            Util.warn('Skipping extractors execution since zero extractors were registered', 'NoExtractors');
+            return;
+        }
+
         let err: Error | null = null,
             lastExt: BaseExtractor | null = null;
 

--- a/packages/discord-player/src/index.ts
+++ b/packages/discord-player/src/index.ts
@@ -14,6 +14,7 @@ export * from './types/types';
 export * from './utils/FFmpegStream';
 export * from './utils/QueryCache';
 export * from './utils/QueryResolver';
+export * from './utils/FFmpeg';
 export * from './Player';
 export * from './hooks';
 export {

--- a/packages/discord-player/src/types/types.ts
+++ b/packages/discord-player/src/types/types.ts
@@ -333,10 +333,8 @@ export interface PlaylistJSON {
 
 /**
  * @typedef {object} PlayerInitOptions
- * @property {boolean} [autoRegisterExtractor=true] If it should automatically register `@discord-player/extractor`
  * @property {YTDLDownloadOptions} [ytdlOptions] The options passed to `ytdl-core`
  * @property {number} [connectionTimeout=20000] The voice connection timeout
- * @property {boolean} [smoothVolume=true] Toggle smooth volume transition
  * @property {boolean} [lagMonitor=30000] Time in ms to re-monitor event loop lag
  * @property {boolean} [lockVoiceStateHandler] Prevent voice state handler from being overridden
  * @property {string[]} [blockExtractors] List of extractors to disable querying metadata from
@@ -345,10 +343,8 @@ export interface PlaylistJSON {
  * @property {boolean} [ignoreInstance] Ignore player instance
  */
 export interface PlayerInitOptions {
-    autoRegisterExtractor?: boolean;
     ytdlOptions?: downloadOptions;
     connectionTimeout?: number;
-    smoothVolume?: boolean;
     lagMonitor?: number;
     lockVoiceStateHandler?: boolean;
     blockExtractors?: string[];

--- a/packages/discord-player/src/utils/FFmpeg.ts
+++ b/packages/discord-player/src/utils/FFmpeg.ts
@@ -1,5 +1,8 @@
 import childProcess from 'child_process';
+import { Duplex, DuplexOptions } from 'stream';
 import { Util } from './Util';
+
+type Callback<Args extends Array<unknown>> = (...args: Args) => unknown;
 
 export interface FFmpegInfo {
     command: string | null;
@@ -8,39 +11,83 @@ export interface FFmpegInfo {
     isStatic: boolean;
 }
 
+export interface FFmpegOptions extends DuplexOptions {
+    args?: string[];
+    shell?: boolean;
+}
+
 const ffmpegInfo: FFmpegInfo = {
     command: null,
     metadata: null,
     version: null,
     isStatic: false
 };
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+// prettier-ignore
 const FFmpegPossibleLocations = [
+    process.env.FFMPEG_PATH,
     'ffmpeg',
     'avconv',
     './ffmpeg',
     './avconv',
     () => {
-        // @ts-expect-error no-module-found
-        return import('ffmpeg-static').then((mod) => <string>(mod.default?.path || mod.path || mod)).catch(() => null);
+        const mod = require('ffmpeg-static');
+        return <string>(mod.default?.path || mod.path || mod);
+    },
+    () => {
+        const mod = require('ffmpeg-binaries');
+        return <string>(mod.default || mod);
     }
 ];
+/* eslint-enable @typescript-eslint/no-var-requires */
 
-export class FFmpeg {
+export class FFmpeg extends Duplex {
     /**
      * FFmpeg version regex
      */
     public static VersionRegex = /version (.+) Copyright/im;
 
     /**
-     * Locate ffmpeg command
+     * Spawns ffmpeg process
+     * @param options Spawn options
+     */
+    public static spawn({ args = [] as string[], shell = false } = {}) {
+        if (!args.includes('-i')) args.unshift('-i', '-');
+
+        return childProcess.spawn(this.locate()!.command!, args.concat(['pipe:1']), { windowsHide: true, shell });
+    }
+
+    /**
+     * Check if ffmpeg is available
+     */
+    public static isAvailable() {
+        return typeof this.locateSafe(false)?.command === 'string';
+    }
+
+    /**
+     * Safe locate ffmpeg
+     * @param force if it should relocate the command
+     */
+    public static locateSafe(force = false) {
+        try {
+            return this.locate(force);
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Locate ffmpeg command. Throws error if ffmpeg is not found.
      * @param force Forcefully reload
      */
-    public static async locate(force = false) {
+    public static locate(force = false): FFmpegInfo | undefined {
         if (ffmpegInfo.command && !force) return ffmpegInfo;
 
         for (const locator of FFmpegPossibleLocations) {
+            if (locator == null) continue;
             try {
-                const command = typeof locator === 'function' ? await locator() : locator;
+                const command = typeof locator === 'function' ? locator() : locator;
                 if (!command) continue;
 
                 const { error, output } = childProcess.spawnSync(command, ['-h'], {
@@ -67,8 +114,107 @@ export class FFmpeg {
             throw new Error([
                 'Could not locate ffmpeg. Tried:\n',
                 ...FFmpegPossibleLocations.filter((f) => typeof f === 'string').map((m) => `- spawn ${m}`),
-                '- ffmpeg-static'
+                '- ffmpeg-static',
+                '- ffmpeg-binaries'
             ].join('\n'));
         }
+    }
+
+    /**
+     * Current FFmpeg process
+     */
+    public process: childProcess.ChildProcessWithoutNullStreams;
+
+    /**
+     * Create FFmpeg duplex stream
+     * @param options Options to initialize ffmpeg
+     * @example ```typescript
+     * const ffmpeg = new FFmpeg({
+     *   args: [
+     *     '-analyzeduration', '0',
+     *     '-loglevel', '0',
+     *     '-f', 's16le',
+     *     '-ar', '48000',
+     *     '-ac', '2',
+     *     '-af', 'bass=g=10,acompressor'
+     *   ]
+     * });
+     *
+     * const pcm = input.pipe(ffmpeg);
+     *
+     * pcm.pipe(fs.createWriteStream('./audio.pcm'));
+     * ```
+     */
+    public constructor(options: FFmpegOptions = {}) {
+        super(options);
+
+        this.process = FFmpeg.spawn(options);
+
+        const EVENTS = {
+            readable: this._reader,
+            data: this._reader,
+            end: this._reader,
+            unpipe: this._reader,
+            finish: this._writer,
+            drain: this._writer
+        } as const;
+
+        // @ts-expect-error
+        this._readableState = this._reader._readableState;
+        // @ts-expect-error
+        this._writableState = this._writer._writableState;
+
+        this._copy(['write', 'end'], this._writer);
+        this._copy(['read', 'setEncoding', 'pipe', 'unpipe'], this._reader);
+
+        for (const method of ['on', 'once', 'removeListener', 'removeAllListeners', 'listeners'] as const) {
+            // @ts-expect-error
+            this[method] = (ev, fn) => (EVENTS[ev] ? EVENTS[ev][method](ev, fn) : Duplex.prototype[method].call(this, ev, fn));
+        }
+
+        const processError = (error: Error) => this.emit('error', error);
+
+        this._reader.on('error', processError);
+        this._writer.on('error', processError);
+    }
+
+    get _reader() {
+        return this.process!.stdout;
+    }
+    get _writer() {
+        return this.process!.stdin;
+    }
+
+    private _copy(methods: string[], target: unknown) {
+        for (const method of methods) {
+            // @ts-expect-error
+            this[method] = target[method].bind(target);
+        }
+    }
+
+    public _destroy(err: Error | null, cb: Callback<[Error | null]>) {
+        this._cleanup();
+        if (cb) return cb(err);
+    }
+
+    public _final(cb: Callback<[]>) {
+        this._cleanup();
+        cb();
+    }
+
+    private _cleanup() {
+        if (this.process) {
+            this.once('error', () => {
+                //
+            });
+            this.process.kill('SIGKILL');
+            this.process = null as unknown as childProcess.ChildProcessWithoutNullStreams;
+        }
+    }
+
+    public toString() {
+        if (!ffmpegInfo.metadata) return 'FFmpeg';
+
+        return ffmpegInfo.metadata;
     }
 }

--- a/packages/discord-player/src/utils/FFmpeg.ts
+++ b/packages/discord-player/src/utils/FFmpeg.ts
@@ -1,0 +1,57 @@
+import childProcess from 'child_process';
+import { Util } from './Util';
+
+export interface FFmpegInfo {
+    command: string | null;
+    metadata: string | null;
+    isStatic: boolean;
+}
+
+const ffmpegInfo: FFmpegInfo = {
+    command: null,
+    metadata: null,
+    isStatic: false
+};
+const FFmpegPossibleLocations = [
+    'ffmpeg',
+    'avconv',
+    './ffmpeg',
+    './avconv',
+    () => {
+        // @ts-expect-error no-module-found
+        return import('ffmpeg-static').then((mod) => <string>(mod.default?.path || mod.path || mod)).catch(() => null);
+    }
+];
+
+export class FFmpeg {
+    public static async locate(force = false) {
+        if (ffmpegInfo.command && !force) return ffmpegInfo;
+
+        for (const locator of FFmpegPossibleLocations) {
+            try {
+                const command = typeof locator === 'function' ? await locator() : locator;
+                if (!command) continue;
+
+                const { error, output } = childProcess.spawnSync(command, ['-h'], {
+                    windowsHide: true
+                });
+
+                if (error) continue;
+
+                ffmpegInfo.command = command;
+                ffmpegInfo.metadata = Buffer.concat(output.filter(Boolean) as Buffer[]).toString('utf-8');
+                ffmpegInfo.isStatic = typeof locator === 'function';
+
+                if (ffmpegInfo.isStatic) {
+                    Util.warn('Found ffmpeg-static which is known to be unstable.', 'FFmpegStaticWarning');
+                }
+
+                return ffmpegInfo;
+            } catch {
+                //
+            }
+
+            throw new Error(['Could not locate ffmpeg. Tried:\n', ...FFmpegPossibleLocations.filter((f) => typeof f === 'string').map((m) => `- spawn ${m}`), '- ffmpeg-static'].join('\n'));
+        }
+    }
+}

--- a/packages/discord-player/src/utils/FFmpeg.ts
+++ b/packages/discord-player/src/utils/FFmpeg.ts
@@ -42,7 +42,7 @@ export class FFmpeg {
                 ffmpegInfo.metadata = Buffer.concat(output.filter(Boolean) as Buffer[]).toString('utf-8');
                 ffmpegInfo.isStatic = typeof locator === 'function';
 
-                if (ffmpegInfo.isStatic) {
+                if (ffmpegInfo.isStatic && !('DP_NO_FFMPEG_WARN' in process.env)) {
                     Util.warn('Found ffmpeg-static which is known to be unstable.', 'FFmpegStaticWarning');
                 }
 

--- a/packages/discord-player/src/utils/FFmpegStream.ts
+++ b/packages/discord-player/src/utils/FFmpegStream.ts
@@ -1,5 +1,5 @@
-import * as prism from 'prism-media';
 import type { Duplex, Readable } from 'stream';
+import { FFmpeg } from './FFmpeg';
 
 export interface FFmpegStreamOptions {
     fmt?: string;
@@ -55,8 +55,7 @@ export function createFFmpegStream(stream: Readable | Duplex | string, options?:
     if (!Number.isNaN(options.seek)) args.unshift('-ss', String(options.seek));
     if (Array.isArray(options.encoderArgs)) args.push(...options.encoderArgs);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const transcoder = new (prism.FFmpeg || (<any>prism).default.FFmpeg)({ shell: false, args });
+    const transcoder = new FFmpeg({ shell: false, args });
     transcoder.on('close', () => transcoder.destroy());
 
     if (typeof stream !== 'string') {


### PR DESCRIPTION
## Changes

This custom ffmpeg stream implementation is based on prism-media's ffmpeg stream with some changes to fit discord-player's need. Users dont have to do anything, it is simply swapped out in internal code. This change also removes deprecated options from player and improves `player.scanDeps()` method.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.