### PR TITLE
docs: add wego overseer to community resources

### DIFF
--- a/docs/community/community_resources.md
+++ b/docs/community/community_resources.md
@@ -29,5 +29,6 @@ An unofficial extractor for discord-player to add support for deezer source.
 | [AtlantaBot](https://github.com/Androz2091/AtlantaBot) | We are using discord-player to manager all of our music commands. | v4.1.0 |
 | [Beat-Bot](https://github.com/IslandRhythms/Beat-Bot) | Fun discord bot with helpful util commands and music player using discord-player. | v6.1.1 |
 | [Melody](https://github.com/NerdyTechy/Melody) | Useful Discord music bot with many commands and effects to spice up your music. | v6.1.1 |
+| [Wego Overseer](https://github.com/rickklaasboer/wego-overseer) | Using discord-player to manage Wego Overseer's music functionality | v6.2.1 |
 
 > Add your own bot/project by creating a [pull request](https://github.com/Androz2091/discord-player).


### PR DESCRIPTION
## Changes
Added [Wego Overseer](https://github.com/rickklaasboer/wego-overseer) to community resources.

Music commands visible [here](https://github.com/rickklaasboer/wego-overseer/tree/main/src/commands/music).

## Status

- [ ] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.