### PR TITLE
Fix typo for userVoiceChannel in the documention

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Let's move on to the command part. You can define the command as per your requir
 
 ```js
 async function execute(interaction) {
-    const channel = interaction.message.member.voice.channel;
+    const channel = interaction.member.voice.channel;
     if (!channel) return interaction.reply('You are not connected to a voice channel!'); // make sure we have a voice channel
     const query = interaction.options.getString('query', true); // we need input/query to play
 

--- a/apps/website/src/pages/guide/_guides/migrating/migrating.mdx
+++ b/apps/website/src/pages/guide/_guides/migrating/migrating.mdx
@@ -95,7 +95,7 @@ import { useMainPlayer } from 'discord-player';
 
 async function execute(interaction) {
     const player = useMainPlayer(); // Get the player instance that we created earlier
-    const channel = interaction.message.member.voice.channel;
+    const channel = interaction.member.voice.channel;
     if (!channel) return interaction.reply('You are not connected to a voice channel!'); // make sure we have a voice channel
     const query = interaction.options.getString('query', true); // we need input/query to play
 

--- a/apps/website/src/pages/guide/_guides/welcome/welcome.mdx
+++ b/apps/website/src/pages/guide/_guides/welcome/welcome.mdx
@@ -136,7 +136,7 @@ Let's move on to the command part. You can define the command as per your requir
 
 ```js play.js
 async function execute(interaction) {
-    const channel = interaction.message.member.voice.channel;
+    const channel = interaction.member.voice.channel;
     if (!channel) return interaction.reply('You are not connected to a voice channel!'); // make sure we have a voice channel
     const query = interaction.options.getString('query', true); // we need input/query to play
 

--- a/packages/discord-player/README.md
+++ b/packages/discord-player/README.md
@@ -121,7 +121,7 @@ Let's move on to the command part. You can define the command as per your requir
 
 ```js
 async function execute(interaction) {
-    const channel = interaction.message.member.voice.channel;
+    const channel = interaction.member.voice.channel;
     if (!channel) return interaction.reply('You are not connected to a voice channel!'); // make sure we have a voice channel
     const query = interaction.options.getString('query', true); // we need input/query to play
 


### PR DESCRIPTION
In the guide, you're using
```js
const channel = interaction.message.member.voice.channel;
```
to get the voice channel of the user. But when I looked in the discordjs documention, there is no `message` property for `commandInteraction`, tough there is `message` property for other interaction. But you can directly access the channel like this too, which I'm using in my music bot too
```js
const channel = interaction.member.voice.channel;
```

## Changes
<!-- describe what changes this PR includes and explain why are they needed -->

## Status

- [ ] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.