### PR TITLE
feat: introduce BridgeSource

### DIFF
--- a/apps/music-bot/src/KarasuClient.ts
+++ b/apps/music-bot/src/KarasuClient.ts
@@ -6,6 +6,7 @@ import { envParseArray } from '@skyra/env-utilities';
 import * as Permissions from './lib/perms';
 import path from 'path';
 import { mkdirSync, existsSync } from 'fs';
+import { BridgeProvider, BridgeSource } from '@discord-player/extractor';
 
 export class KarasuClient extends SapphireClient {
 	public player: Player;
@@ -28,7 +29,12 @@ export class KarasuClient extends SapphireClient {
 		});
 		this.dev = Emojis;
 		this.perms = Permissions;
+
+		const bridgeProvider = new BridgeProvider();
+		bridgeProvider.setBridgeSource(BridgeSource.SoundCloud);
+
 		this.player = new Player(this as any, {
+			bridgeProvider,
 			ytdlOptions: {
 				requestOptions: {
 					headers: {

--- a/apps/music-bot/src/KarasuClient.ts
+++ b/apps/music-bot/src/KarasuClient.ts
@@ -30,8 +30,7 @@ export class KarasuClient extends SapphireClient {
 		this.dev = Emojis;
 		this.perms = Permissions;
 
-		const bridgeProvider = new BridgeProvider();
-		bridgeProvider.setBridgeSource(BridgeSource.SoundCloud);
+		const bridgeProvider = new BridgeProvider(BridgeSource.SoundCloud);
 
 		this.player = new Player(this as any, {
 			bridgeProvider,

--- a/apps/website/src/pages/guide/_guides/extractors/set_bridge_source.mdx
+++ b/apps/website/src/pages/guide/_guides/extractors/set_bridge_source.mdx
@@ -1,0 +1,31 @@
+# Setting Bridge Source
+
+Extractors such as `SpotifyExtractor` and `AppleMusicExtractor` cannot facilitate the audio streaming functionality. Bridging is a mechanism that allows extractors such as `AppleMusicExtractor` and `SpotifyExtractor` to provide audio stream from alternative sources. The default source for this particular case has been `YouTube` for a long time and overriding this behavior has been difficult.
+
+The `BridgeProvider` API allows overriding default bridging mechanism and enables us to pick which source shall be used. Currently, `BridgeProvider` only supports `SoundCloud` and `YouTube` as its bridging source.
+
+A quick example on how to set up `BridgeProvider` using `SoundCloud` as its bridge source:
+
+### Global
+
+```js
+import { BridgeProvider, BridgeSource } from '@discord-player/extractor';
+
+const bridgeProvider = new BridgeProvider(BridgeSource.SoundCloud);
+
+const player = new Player(client, {
+    bridgeProvider
+});
+```
+
+### Individual
+
+```js
+import { BridgeProvider, BridgeSource, SpotifyExtractor } from '@discord-player/extractor';
+
+const bridgeProvider = new BridgeProvider(BridgeSource.SoundCloud);
+
+await player.extractors.register(SpotifyExtractor, {
+    bridgeProvider
+});
+```

--- a/apps/website/src/pages/guide/index.tsx
+++ b/apps/website/src/pages/guide/index.tsx
@@ -47,6 +47,7 @@ const entries = {
     },
     Extractors: {
         'Creating Extractor': lazy(() => import('./_guides/extractors/creating_extractor.mdx')),
+        'Setting Bridge Source': lazy(() => import('./_guides/extractors/set_bridge_source.mdx')),
         'Stream Sources': lazy(() => import('./_guides/extractors/stream_sources.mdx'))
     },
     FAQ: {

--- a/packages/discord-player/src/manager/GuildNodeManager.ts
+++ b/packages/discord-player/src/manager/GuildNodeManager.ts
@@ -75,7 +75,7 @@ export class GuildNodeManager<Meta = unknown> {
         options.bufferingTimeout ??= 1000;
         options.maxSize ??= Infinity;
         options.maxHistorySize ??= Infinity;
-        options.preferBridgedMetadata = Boolean(options.preferBridgedMetadata);
+        options.preferBridgedMetadata ??= true;
 
         if (getGlobalRegistry().has('@[onBeforeCreateStream]') && !options.onBeforeCreateStream) {
             options.onBeforeCreateStream = getGlobalRegistry().get('@[onBeforeCreateStream]') as OnBeforeCreateStreamHandler;

--- a/packages/discord-player/src/types/types.ts
+++ b/packages/discord-player/src/types/types.ts
@@ -5,6 +5,9 @@ import { Playlist } from '../fabric/Playlist';
 import { downloadOptions } from 'ytdl-core';
 import { QueryCache } from '../utils/QueryCache';
 
+// @ts-ignore
+import type { BridgeProvider } from '@discord-player/extractor';
+
 export type FiltersName = keyof QueueFilters;
 
 export interface PlayerSearchResult {
@@ -342,6 +345,7 @@ export interface PlaylistJSON {
  * @property {QueryCache | null} [queryCache] Query cache provider
  * @property {boolean} [ignoreInstance] Ignore player instance
  * @property {boolean} [useLegacyFFmpeg] Use legacy version of ffmpeg
+ * @property {BridgeProvider} [bridgeProvider] Set bridge provider
  */
 export interface PlayerInitOptions {
     ytdlOptions?: downloadOptions;
@@ -353,4 +357,5 @@ export interface PlayerInitOptions {
     queryCache?: QueryCache | null;
     ignoreInstance?: boolean;
     useLegacyFFmpeg?: boolean;
+    bridgeProvider?: BridgeProvider;
 }

--- a/packages/extractor/src/extractors/AppleMusicExtractor.ts
+++ b/packages/extractor/src/extractors/AppleMusicExtractor.ts
@@ -3,9 +3,11 @@ import { AppleMusic } from '../internal';
 import { Readable } from 'stream';
 import { YoutubeExtractor } from './YoutubeExtractor';
 import { StreamFN, loadYtdl, pullYTMetadata } from './common/helper';
+import { BridgeProvider } from './common/BridgeProvider';
 
 export interface AppleMusicExtractorInit {
     createStream?: (ext: AppleMusicExtractor, url: string) => Promise<Readable | string>;
+    bridgeProvider?: BridgeProvider;
 }
 
 export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> {
@@ -14,6 +16,9 @@ export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> 
     private _isYtdl = false;
 
     public async activate(): Promise<void> {
+        // skip if we have a bridge provider
+        if (this.options.bridgeProvider) return;
+
         const fn = this.options.createStream;
 
         if (typeof fn === 'function') {
@@ -80,7 +85,7 @@ export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> 
                             requestMetadata: async () => {
                                 return {
                                     source: m,
-                                    bridge: await pullYTMetadata(this, track)
+                                    bridge: this.options.bridgeProvider ? (await this.options.bridgeProvider.resolve(this, track)).data : await pullYTMetadata(this, track)
                                 };
                             }
                         });
@@ -135,7 +140,7 @@ export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> 
                             requestMetadata: async () => {
                                 return {
                                     source: info,
-                                    bridge: await pullYTMetadata(this, track)
+                                    bridge: this.options.bridgeProvider ? (await this.options.bridgeProvider.resolve(this, track)).data : await pullYTMetadata(this, track)
                                 };
                             }
                         });
@@ -189,7 +194,7 @@ export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> 
                             requestMetadata: async () => {
                                 return {
                                     source: m,
-                                    bridge: await pullYTMetadata(this, track)
+                                    bridge: this.options.bridgeProvider ? (await this.options.bridgeProvider.resolve(this, track)).data : await pullYTMetadata(this, track)
                                 };
                             }
                         });
@@ -225,7 +230,7 @@ export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> 
                     requestMetadata: async () => {
                         return {
                             source: info,
-                            bridge: await pullYTMetadata(this, track)
+                            bridge: this.options.bridgeProvider ? (await this.options.bridgeProvider.resolve(this, track)).data : await pullYTMetadata(this, track)
                         };
                     }
                 });
@@ -240,6 +245,20 @@ export class AppleMusicExtractor extends BaseExtractor<AppleMusicExtractorInit> 
     }
 
     public async stream(info: Track): Promise<string | Readable> {
+        if (this.options.bridgeProvider) {
+            const provider = this.options.bridgeProvider;
+
+            const data = await provider.resolve(this, info);
+            if (!data) throw new Error('Failed to bridge this track');
+
+            info.setMetadata({
+                ...(info.metadata || {}),
+                bridge: data.data
+            });
+
+            return await provider.stream(data);
+        }
+
         if (!this._stream) {
             throw new Error(`Could not initialize streaming api for '${this.constructor.name}'`);
         }

--- a/packages/extractor/src/extractors/SoundCloudExtractor.ts
+++ b/packages/extractor/src/extractors/SoundCloudExtractor.ts
@@ -20,11 +20,17 @@ export interface SoundCloudExtractorInit {
 export class SoundCloudExtractor extends BaseExtractor<SoundCloudExtractorInit> {
     public static identifier = 'com.discord-player.soundcloudextractor' as const;
 
+    public static soundcloud: import('soundcloud.ts').default | null = null;
+
     public internal = new SoundCloud.default({
         clientId: this.options.clientId,
         oauthToken: this.options.oauthToken,
         proxy: this.options.proxy
     });
+
+    public async activate(): Promise<void> {
+        SoundCloudExtractor.soundcloud = this.internal;
+    }
 
     public async validate(query: string, type?: SearchQueryType | null | undefined): Promise<boolean> {
         if (typeof query !== 'string') return false;

--- a/packages/extractor/src/extractors/common/BridgeProvider.ts
+++ b/packages/extractor/src/extractors/common/BridgeProvider.ts
@@ -1,0 +1,74 @@
+import { BaseExtractor, Track } from 'discord-player';
+import { SoundcloudTrackV2 } from 'soundcloud.ts';
+import { Video } from 'youtube-sr';
+import { SoundCloudExtractor } from '../SoundCloudExtractor';
+import { loadYtdl, pullSCMetadata, pullYTMetadata } from './helper';
+
+export enum BridgeSource {
+    SoundCloud = 'soundcloud',
+    YouTube = 'youtube'
+}
+
+export type IBridgeSource = 'soundcloud' | 'youtube';
+
+export class BridgeProvider {
+    public bridgeSource: BridgeSource = BridgeSource.SoundCloud;
+
+    public constructor(source: IBridgeSource) {
+        this.setBridgeSource(source);
+    }
+
+    public setBridgeSource(source: BridgeSource | IBridgeSource) {
+        switch (source) {
+            case 'soundcloud':
+            case BridgeSource.SoundCloud:
+                this.bridgeSource = BridgeSource.SoundCloud;
+                break;
+            case 'youtube':
+            case BridgeSource.YouTube:
+                this.bridgeSource = BridgeSource.YouTube;
+                break;
+            default:
+                throw new TypeError('invalid bridge source');
+        }
+    }
+
+    public isSoundCloud() {
+        return this.bridgeSource === BridgeSource.SoundCloud;
+    }
+
+    public isYouTube() {
+        return this.bridgeSource === BridgeSource.YouTube;
+    }
+
+    public async resolve(ext: BaseExtractor, track: Track) {
+        const isSoundcloud = this.isSoundCloud();
+        const bridgefn = isSoundcloud ? pullSCMetadata : pullYTMetadata;
+
+        // patch query
+        const oldQc = ext.createBridgeQuery;
+        if (isSoundcloud) ext.createBridgeQuery = (track) => `${track.author} ${track.title}`;
+        const res = await bridgefn(ext, track);
+        ext.createBridgeQuery = oldQc;
+
+        return { source: isSoundcloud ? 'soundcloud' : 'youtube', data: res } as BridgedMetadata;
+    }
+
+    public async stream(meta: BridgedMetadata) {
+        if (meta.source === 'soundcloud') {
+            if (!SoundCloudExtractor.soundcloud) {
+                throw new Error('Could not find soundcloud client, make sure SoundCloudExtractor is instantiated properly.');
+            }
+
+            return await SoundCloudExtractor.soundcloud.util.streamLink(meta.data as SoundcloudTrackV2, 'progressive');
+        } else {
+            const ytdl = await loadYtdl();
+            return ytdl.stream((meta.data as Video).url);
+        }
+    }
+}
+
+interface BridgedMetadata {
+    source: IBridgeSource;
+    data: SoundcloudTrackV2 | Video | null;
+}

--- a/packages/extractor/src/extractors/common/helper.ts
+++ b/packages/extractor/src/extractors/common/helper.ts
@@ -1,5 +1,6 @@
 import { BaseExtractor, Track } from 'discord-player';
 import { YouTube } from 'youtube-sr';
+import { SoundCloudExtractor } from '../SoundCloudExtractor';
 
 let factory: {
     name: string;
@@ -142,8 +143,34 @@ export async function makeYTSearch(query: string, opt: any) {
     return res || [];
 }
 
+export async function makeSCSearch(query: string) {
+    const { soundcloud } = SoundCloudExtractor;
+    if (!soundcloud) return [];
+
+    try {
+        const info = await soundcloud.tracks.searchV2({
+            q: query
+        });
+
+        return info.collection;
+    } catch {
+        // fallback
+        const info = await soundcloud.tracks.searchAlt(query);
+
+        return info;
+    }
+}
+
 export async function pullYTMetadata(ext: BaseExtractor, info: Track) {
     const meta = await makeYTSearch(ext.createBridgeQuery(info), 'video')
+        .then((r) => r[0])
+        .catch(() => null);
+
+    return meta;
+}
+
+export async function pullSCMetadata(ext: BaseExtractor, info: Track) {
+    const meta = await makeSCSearch(ext.createBridgeQuery(info))
         .then((r) => r[0])
         .catch(() => null);
 

--- a/packages/extractor/src/extractors/common/helper.ts
+++ b/packages/extractor/src/extractors/common/helper.ts
@@ -149,7 +149,8 @@ export async function makeSCSearch(query: string) {
 
     try {
         const info = await soundcloud.tracks.searchV2({
-            q: query
+            q: query,
+            limit: 5
         });
 
         return info.collection;

--- a/packages/extractor/src/extractors/index.ts
+++ b/packages/extractor/src/extractors/index.ts
@@ -7,3 +7,4 @@ export * from './AttachmentExtractor';
 export * from './AppleMusicExtractor';
 export * from './SpotifyExtractor';
 export * from './common/helper';
+export * from './common/BridgeProvider';

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -17,6 +17,7 @@
         "forceConsistentCasingInFileNames": true
     },
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "dist"
     ]
 }


### PR DESCRIPTION
## Changes

TLDR; This PR introduces `BridgeProvider` which allows some extractors to conditionally stream from the specified source.

Extractors such as `SpotifyExtractor` and `AppleMusicExtractor` cannot facilitate the audio streaming functionality. Bridging is a mechanism that allows extractors such as `AppleMusicExtractor` and `SpotifyExtractor` to provide audio stream from alternative sources. The default source for this particular case has been `YouTube` for a long time and overriding this behavior has been difficult.

The `BridgeProvider` API allows overriding default bridging mechanism and enables us to pick which source shall be used. Currently, `BridgeProvider` only supports `SoundCloud` and `YouTube` as its bridging source.

A quick example on how to set up `BridgeProvider` using `SoundCloud` as its bridge source:

### Global

```js
import { BridgeProvider, BridgeSource } from '@discord-player/extractor';

const bridgeProvider = new BridgeProvider(BridgeSource.SoundCloud);

const player = new Player(client, {
    bridgeProvider
});
```

### Individual

```js
import { BridgeProvider, BridgeSource, SpotifyExtractor } from '@discord-player/extractor';

const bridgeProvider = new BridgeProvider(BridgeSource.SoundCloud);

await player.extractors.register(SpotifyExtractor, {
    bridgeProvider
});
```

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.