### PR TITLE
Rename bot in showcase

### DIFF
--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -140,10 +140,10 @@ export const ShowcaseResource: IShowcase = {
             url: 'https://github.com/Androz2091/AtlantaBot'
         },
         {
-            name: 'Radio Bot',
+            name: 'Cadence Bot',
             description: 'A free music and audio bot for Discord. No locked functionality, free forever. Open source.',
             version: 'v6.6.0',
-            url: 'https://github.com/mariusbegby/radio-discord-bot'
+            url: 'https://github.com/mariusbegby/cadence-discord-bot'
         }
     ].sort((a, b) => semver.rcompare(a.version, b.version)),
     extractors: [


### PR DESCRIPTION
## Changes
Renamed my bot that I previously added to showcase. The reason is that the bot was renamed now before submitting bot verification request to Discord. The name will not change any more.

## Status

- [ ] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.