### PR TITLE
emit playerFinish on emptyChannel

### DIFF
--- a/packages/discord-player/src/DefaultVoiceStateHandler.ts
+++ b/packages/discord-player/src/DefaultVoiceStateHandler.ts
@@ -62,6 +62,7 @@ export async function defaultVoiceStateHandler(player: Player, queue: GuildQueue
                     if (!player.nodes.has(queue.guild.id)) return;
                     if (queue.options.leaveOnEmpty) queue.delete();
                     player.events.emit(GuildQueueEvent.emptyChannel, queue);
+                    player.events.emit(GuildQueueEvent.playerFinish, queue);
                 }, queue.options.leaveOnEmptyCooldown || 0).unref();
                 queue.timeouts.set(`empty_${oldState.guild.id}`, timeout);
             }


### PR DESCRIPTION
i'm not sure if i am doing this right because the track argument is not being passed..., but shouldn't playerFinish be emitted?

## Changes
The playerFinish event should be emitted when the channel is empty!

