### PR TITLE
chore: Update Cadence discord-player version

### DIFF
--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -139,9 +139,9 @@ export const ShowcaseResource: IShowcase = {
             url: 'https://github.com/Androz2091/AtlantaBot'
         },
         {
-            name: 'Cadence Bot',
-            description: 'A free music and audio bot for Discord. No locked functionality, free forever. Open source.',
-            version: 'v6.6.0',
+            name: 'Cadence',
+            description: 'A free music and audio bot for Discord. No locked functionality, free forever. Open source!',
+            version: 'v6.6.2',
             url: 'https://github.com/mariusbegby/cadence-discord-bot'
         }
     ].sort((a, b) => semver.rcompare(a.version, b.version)),


### PR DESCRIPTION
## Changes
- Updated Cadence bot `discord-player` version to `6.6.2`.

## Status

- [ ] These changes have been tested and formatted properly.
- [X] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.