### PR TITLE
chore(SpotifyExtractor): Update spotify-url-info version

### DIFF
--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -50,7 +50,7 @@
     "node-html-parser": "^6.1.4",
     "reverbnation-scraper": "^2.0.0",
     "soundcloud.ts": "^0.5.0",
-    "spotify-url-info": "^3.2.5",
+    "spotify-url-info": "^3.2.6",
     "youtube-sr": "^4.3.4"
   },
   "typedoc": {


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->
Update spotify-url-info version from 3.2.5 to 3.2.6

When using the Spotify extractor the extractor will sporadically fail to find info about a given Track. Updating to the latest minor version fixes this. See: https://github.com/microlinkhq/spotify-url-info/issues/122#issuecomment-1656920131

## Status

- [X] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.