### PR TITLE
[Docs] Mediaplex and discord-player singleton

### DIFF
--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -56,7 +56,7 @@ export const ShowcaseResource: IShowcase = {
         {
             name: 'Jappan',
             description: "A simple discord bot made to make someone's life easier. Currently features Music Playback, Fun Commands, Leveling System & Moderation Tools",
-            version: 'v6.2.1',
+            version: 'v6.6.3',
             url: 'https://github.com/febkosq8/Jappan'
         },
         {

--- a/apps/website/src/pages/guide/_guides/faq/common_errors.mdx
+++ b/apps/website/src/pages/guide/_guides/faq/common_errors.mdx
@@ -2,11 +2,13 @@ import DiscordInvite from '@/components/homepage/DiscordInvite';
 
 # Troubleshooting Common Issues
 
-## Cannot find `opusscript` or `@discordjs/opus` or `node-opus`
+## Cannot find `mediaplex` or `opusscript` or `@discordjs/opus` or `node-opus`
 
 To resolve this issue, you need to install the opus encoder. Use one of the following commands based on your preference:
 
 ```sh
+$ yarn add mediaplex
+# or
 $ yarn add @discordjs/opus
 # or
 $ yarn add opusscript
@@ -26,6 +28,7 @@ You have several options to get FFmpeg:
 
 -   Download it from the official FFmpeg website: [www.ffmpeg.org/download.html](https://www.ffmpeg.org/download.html)
 -   Use the Node Module (ffmpeg-static): [npmjs.com/package/ffmpeg-static](https://npmjs.com/package/ffmpeg-static) (Note: Using static binaries like `ffmpeg-static` is not recommended)
+-   You can dockerize your bot with a Node environment (Example : 18.16.0-bullseye) that can have ffmpeg installed.
 -   Alternatively, if you prefer using Avconv instead of FFmpeg, install it on your system or place the Avconv executable at the root of your project.
 
 ## Audio player stops immediately without errors

--- a/apps/website/src/pages/guide/_guides/faq/common_errors.mdx
+++ b/apps/website/src/pages/guide/_guides/faq/common_errors.mdx
@@ -28,7 +28,7 @@ You have several options to get FFmpeg:
 
 -   Download it from the official FFmpeg website: [www.ffmpeg.org/download.html](https://www.ffmpeg.org/download.html)
 -   Use the Node Module (ffmpeg-static): [npmjs.com/package/ffmpeg-static](https://npmjs.com/package/ffmpeg-static) (Note: Using static binaries like `ffmpeg-static` is not recommended)
--   You can dockerize your bot with a Node environment (Example : 18.16.0-bullseye) that can have ffmpeg installed.
+-   You can dockerize your bot with a Node environment (Example : 18.16.0-bullseye) that can have ffmpeg installed. Check Showcase for sample implementations.
 -   Alternatively, if you prefer using Avconv instead of FFmpeg, install it on your system or place the Avconv executable at the root of your project.
 
 ## Audio player stops immediately without errors

--- a/apps/website/src/pages/guide/_guides/faq/how_to_access_player.mdx
+++ b/apps/website/src/pages/guide/_guides/faq/how_to_access_player.mdx
@@ -6,18 +6,16 @@ We have seen a lot of examples where we could assign `Player` to `client.player`
 client.player = player;
 ```
 
-This would also remove intellisense as `client` does not have a property called `player`. To solve this issue, discord-player provides singleton constructor support. You just need to update your code to the following:
+This would remove intellisense as `client` does not have a property called `player`. To solve this issue, discord-player by default provides singleton constructor support. You will need to create a instance of player as shown below:
 
-```diff
-- const player = new Player(client);
-+ const player = Player.singleton(client);
+```js
+const player = new Player(client);
 ```
-
-> Note: Discord Player is by default a singleton, so `const player = new Player(client);` works the same as `Player.singleton(client)`. You can bypass singleton behavior using `const player = new Player(client, { ignoreInstance: true });`
 
 The code above will not create duplicate instances of `Player`. Each time you call `Player.singleton()`, you will receive the same instance and full intellisense.
 
-> `Player.singleton()` creates a single instance of player which is shared in the future. You can simply do `Player.singleton()` to access player instance whenever you want without polluting client.
+> Note: Discord Player is by default a singleton. You can bypass singleton behavior using `const player = new Player(client, { ignoreInstance: true });`
+
 
 Once you initialize Player, you can access that instance of player from anywhere as shown below:
 


### PR DESCRIPTION
## Changes
- [Docs] Mediaplex is a option for Opux Encoding
- [Docs] Discord Player is singleton by default
- [Docs] Dockerize for ffmpeg
- [Showcase] Updated Jappan discord-player version

## Status

- [ ] These changes have been tested and formatted properly.
- [ X] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.