### PR TITLE
feat: add serialization and deserialization methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Discord Player is a robust framework for developing Discord Music bots using Jav
 -   Offers easy debugging methods
 -   Out-of-the-box voice states handling
 -   IP Rotation support
+-   Easy serialization and deserialization
 
 ## Installation
 

--- a/packages/discord-player/__test__/serde.spec.ts
+++ b/packages/discord-player/__test__/serde.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { Client, IntentsBitField } from 'discord.js';
+import { decode, deserialize, encode, Player, Playlist, serialize, SerializedType, Track } from '../src';
+
+describe('serde', () => {
+    const client = new Client({
+        intents: [IntentsBitField.Flags.GuildVoiceStates]
+    });
+
+    const player = new Player(client);
+
+    const dummyData = {
+        track: new Track(player, {
+            title: 'test',
+            description: 'test',
+            author: 'test',
+            duration: '02:00',
+            queryType: 'AUTO',
+            url: 'https://example.com',
+            views: 0,
+            source: 'arbitrary',
+            thumbnail: 'https://example.com'
+        }),
+        playlist: new Playlist(player, {
+            title: 'test',
+            description: 'test',
+            author: {
+                name: 'test',
+                url: 'https://example.com'
+            },
+            id: 'test',
+            source: 'arbitrary',
+            thumbnail: 'https://example.com',
+            tracks: Array.from(
+                { length: 10 },
+                () =>
+                    new Track(player, {
+                        title: 'test',
+                        description: 'test',
+                        author: 'test',
+                        duration: '02:00',
+                        queryType: 'AUTO',
+                        url: 'https://example.com',
+                        views: 0,
+                        source: 'arbitrary',
+                        thumbnail: 'https://example.com'
+                    })
+            ),
+            type: 'album',
+            url: 'https://example.com'
+        })
+    };
+
+    it('should serialize and deserialize track', async () => {
+        const serialized = serialize(dummyData.track);
+
+        expect(serialized.$type).toBe(SerializedType.Track);
+
+        const track2 = deserialize(player, serialized);
+
+        expect(track2).toBeInstanceOf(Track);
+        expect(track2.title).toBe(serialized.title);
+    });
+
+    it('should encode and decode track', async () => {
+        const serialized = serialize(dummyData.track);
+        const encoded = encode(serialized);
+        const decoded = decode(encoded);
+
+        expect(encoded).toBeTypeOf('string');
+        expect(decoded).toStrictEqual(serialized);
+    });
+
+    it('should serialize and deserialize playlist', async () => {
+        const serialized = serialize(dummyData.playlist);
+
+        expect(serialized.$type).toBe(SerializedType.Playlist);
+
+        const list = deserialize(player, serialized);
+
+        expect(list).toBeInstanceOf(Playlist);
+        expect(list.title).toBe(serialized.title);
+    });
+
+    it('should encode and decode playlist', async () => {
+        const serialized = serialize(dummyData.track);
+        const encoded = encode(serialized);
+        const decoded = decode(encoded);
+
+        expect(encoded).toBeTypeOf('string');
+        expect(decoded).toStrictEqual(serialized);
+    });
+});

--- a/packages/discord-player/src/errors/index.ts
+++ b/packages/discord-player/src/errors/index.ts
@@ -3,112 +3,126 @@ const DiscordPlayerErrors = {
         name: 'ERR_OUT_OF_SPACE',
         type: RangeError,
         createError(target: string, capacity: number, total: number) {
-            return `Max capacity reached for ${target} (Capacity ${capacity}/Total ${total})`;
+            return `[${this.name}] Max capacity reached for ${target} (Capacity ${capacity}/Total ${total})`;
         }
     },
     ERR_INVALID_ARG_TYPE: {
         name: 'ERR_INVALID_ARG_TYPE',
         type: TypeError,
         createError(target: string, expectation: string, found: string) {
-            return `Expected ${target} to be "${expectation}", received "${found}"`;
+            return `[${this.name}] Expected ${target} to be "${expectation}", received "${found}"`;
         }
     },
     ERR_NO_RESULT: {
         name: 'ERR_NO_RESULT',
         type: Error,
         createError(message: string) {
-            return message;
+            return `[${this.name}] ${message}`;
         }
     },
     ERR_NOT_IMPLEMENTED: {
         name: 'ERR_NOT_IMPLEMENTED',
         type: Error,
         createError(target: string) {
-            return `${target} is not yet implemented`;
+            return `[${this.name}] ${target} is not yet implemented`;
         }
     },
     ERR_NOT_EXISTING: {
         name: 'ERR_NOT_EXISTING',
         type: Error,
         createError(target: string) {
-            return `${target} does not exist`;
+            return `[${this.name}] ${target} does not exist`;
         }
     },
     ERR_OUT_OF_RANGE: {
         name: 'ERR_OUT_OF_RANGE',
         type: RangeError,
         createError(target: string, value: string, minimum: string, maximum: string) {
-            return `${target} is out of range (Expected minimum ${maximum} and maximum ${maximum}, got ${value})`;
+            return `[${this.name}] ${target} is out of range (Expected minimum ${maximum} and maximum ${maximum}, got ${value})`;
         }
     },
     ERR_NO_VOICE_CONNECTION: {
         name: 'ERR_NO_VOICE_CONNECTION',
         type: Error,
         createError(message?: string) {
-            return message || 'No voice connection available, maybe connect to a voice channel first?';
+            return `[${this.name}] ` + (message || 'No voice connection available, maybe connect to a voice channel first?');
         }
     },
     ERR_VOICE_CONNECTION_DESTROYED: {
         name: 'ERR_VOICE_CONNECTION_DESTROYED',
         type: Error,
         createError() {
-            return 'Cannot use destroyed voice connection';
+            return `[${this.name}] ` + 'Cannot use destroyed voice connection';
         }
     },
     ERR_NO_VOICE_CHANNEL: {
         name: 'ERR_NO_VOICE_CHANNEL',
         type: Error,
         createError() {
-            return 'Could not get the voice channel';
+            return `[${this.name}] ` + 'Could not get the voice channel';
         }
     },
     ERR_INVALID_VOICE_CHANNEL: {
         name: 'ERR_INVALID_VOICE_CHANNEL',
         type: Error,
         createError() {
-            return 'Expected a voice channel';
+            return `[${this.name}] ` + 'Expected a voice channel';
         }
     },
     ERR_NO_RECEIVER: {
         name: 'ERR_NO_RECEIVER',
         type: Error,
         createError(message?: string) {
-            return message || 'No voice receiver is available, maybe connect to a voice channel first?';
+            return `[${this.name}] ` + (message || 'No voice receiver is available, maybe connect to a voice channel first?');
         }
     },
     ERR_FFMPEG_LOCATOR: {
         name: 'ERR_FFMPEG_LOCATOR',
         type: Error,
         createError(message: string) {
-            return message;
+            return `[${this.name}] ` + message;
         }
     },
     ERR_NO_AUDIO_RESOURCE: {
         name: 'ERR_NO_AUDIO_RESOURCE',
         type: Error,
         createError(message?: string) {
-            return message || 'Expected an audio resource';
+            return `[${this.name}] ` + (message || 'Expected an audio resource');
         }
     },
     ERR_NO_GUILD_QUEUE: {
         name: 'ERR_NO_GUILD_QUEUE',
         type: Error,
         createError(message?: string) {
-            return message || 'Expected a guild queue';
+            return `[${this.name}] ` + (message || 'Expected a guild queue');
         }
     },
     ERR_NO_GUILD: {
         name: 'ERR_NO_GUILD',
         type: Error,
         createError(message?: string) {
-            return message || 'Expected a guild';
+            return `[${this.name}] ` + (message || 'Expected a guild');
         }
     },
     ERR_INFO_REQUIRED: {
         name: 'ERR_INFO_REQUIRED',
         type: Error,
         createError(target: string, actual: string) {
-            return `Expected ${target}, found "${actual}"`;
+            return `[${this.name}] Expected ${target}, found "${actual}"`;
+        }
+    },
+    ERR_SERIALIZATION_FAILED: {
+        name: 'ERR_SERIALIZATION_FAILED',
+        type: Error,
+        createError() {
+            return `[${this.name}]` + "Don't know how to serialize this data";
+        }
+    },
+    ERR_DESERIALIZATION_FAILED: {
+        name: 'ERR_DESERIALIZATION_FAILED',
+        type: Error,
+        createError() {
+            return `[${this.name}]` + "Don't know how to deserialize this data";
         }
     }
 } as const;

--- a/packages/discord-player/src/index.ts
+++ b/packages/discord-player/src/index.ts
@@ -19,6 +19,7 @@ export * from '@discord-player/ffmpeg';
 export * from './Player';
 export * from './hooks';
 export * from './utils/IPRotator';
+export * from './utils/serde';
 export {
     AudioFilters as PCMAudioFilters,
     type BiquadFilters,

--- a/packages/discord-player/src/utils/serde.ts
+++ b/packages/discord-player/src/utils/serde.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Exceptions } from '../errors';
+import { Playlist, type SerializedTrack, Track, SerializedPlaylist } from '../fabric';
+import { TypeUtil } from './TypeUtil';
+import { Buffer } from 'buffer';
+import { Player } from '../Player';
+
+export enum SerializedType {
+    Track = '$track',
+    Playlist = '$playlist'
+}
+
+export type Encodable = SerializedTrack | SerializedPlaylist;
+
+const isTrack = (data: any): data is SerializedTrack => data.$type === SerializedType.Track;
+const isPlaylist = (data: any): data is SerializedPlaylist => data.$type === SerializedType.Playlist;
+
+export function serialize(data: Track | Playlist | any) {
+    if (data instanceof Track) return data.serialize();
+    if (data instanceof Playlist) return data.serialize();
+
+    try {
+        return data.toJSON();
+    } catch {
+        throw Exceptions.ERR_SERIALIZATION_FAILED();
+    }
+}
+
+export function deserialize(player: Player, data: Encodable) {
+    if (isTrack(data)) return Track.fromSerialized(player, data);
+    if (isPlaylist(data)) return Playlist.fromSerialized(player, data);
+
+    throw Exceptions.ERR_DESERIALIZATION_FAILED();
+}
+
+export function encode(data: Encodable) {
+    const str = JSON.stringify(data);
+
+    return Buffer.from(str).toString('base64');
+}
+
+export function decode(data: string) {
+    const str = Buffer.from(data, 'base64').toString();
+
+    return JSON.parse(str);
+}
+
+export function tryIntoThumbnailString(data: any) {
+    if (!data) return null;
+    try {
+        if (TypeUtil.isString(data)) return data;
+        return data?.url ?? data?.thumbnail?.url ?? null;
+    } catch {
+        return null;
+    }
+}

--- a/packages/extractor/src/extractors/common/helper.ts
+++ b/packages/extractor/src/extractors/common/helper.ts
@@ -134,7 +134,7 @@ export async function loadYtdl(options?: any, force = false) {
                 // return dl(query, this.context.player.options.ytdlOptions);
             } else if (_ytLibName === '@distube/ytdl-core') {
                 const dl = lib as typeof import('@distube/ytdl-core');
-                let opt: any;
+                let opt: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
                 if (planner) {
                     opt = {
@@ -147,6 +147,7 @@ export async function loadYtdl(options?: any, force = false) {
 
                 const agent = dl.createAgent(Array.isArray(cookie) ? cookie : undefined, opt);
 
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const reqOpt: any = {
                     agent
                 };

--- a/packages/extractor/src/extractors/common/helper.ts
+++ b/packages/extractor/src/extractors/common/helper.ts
@@ -173,10 +173,11 @@ export async function loadYtdl(options?: any, force = false) {
                 return url;
             } else if (_ytLibName === 'play-dl') {
                 const dl = lib as typeof import('play-dl');
-                
-                if (options?.requestOptions?.headers?.cookie) dl.setToken({
-                  youtube: options.requestOptions.headers.cookie
-                });
+
+                if (options?.requestOptions?.headers?.cookie)
+                    dl.setToken({
+                        youtube: options.requestOptions.headers.cookie
+                    });
                 const info = await dl.video_info(query);
                 const formats = info.format
                     .filter((format) => {


### PR DESCRIPTION
## Changes

This pr introduces 4 new helper functions:
- `encode()`: Produces base64 representation of serialized data
- `decode()`: Produces serialized json data from encoded string
- `serialize()`: Transforms structures such as `Track` or `Playlist` into raw json
- `deserialize()`: Produces `Track` or `Playlist` from the serialized json data

This is helpful to people who want to store tracks and playlists inside database and quickly re-initialize it.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.