### PR TITLE
fix(serde): remove $ from SerializedType value

### DIFF
--- a/packages/discord-player/src/utils/serde.ts
+++ b/packages/discord-player/src/utils/serde.ts
@@ -7,8 +7,8 @@ import { Buffer } from 'buffer';
 import { Player } from '../Player';
 
 export enum SerializedType {
-    Track = '$track',
-    Playlist = '$playlist'
+    Track = 'track',
+    Playlist = 'playlist'
 }
 
 export type Encodable = SerializedTrack | SerializedPlaylist;


### PR DESCRIPTION
Remove $ from `SerializedType` value since it is mapped by `$type: 'VALUE'`

## Changes
<!-- describe what changes this PR includes and explain why are they needed -->

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes. (It does not break since this feature is not yet released)