### PR TITLE
feat(GuildQueuePlayerNode): implement demuxer

### DIFF
--- a/apps/music-bot/package.json
+++ b/apps/music-bot/package.json
@@ -9,6 +9,7 @@
     "@discord-player/extractor": "workspace:^",
     "@discord-player/utils": "workspace:^",
     "@discordjs/opus": "^0.9.0",
+    "@distube/ytdl-core": "^4.13.2",
     "@sapphire/discord.js-utilities": "^6.0.3",
     "@sapphire/duration": "^1.0.0",
     "@sapphire/framework": "^4.2.1",
@@ -20,7 +21,8 @@
     "discord-api-types": "^0.37.35",
     "discord-player": "workspace:^",
     "mediaplex": "^0.0.2",
-    "opusscript": "^0.0.8"
+    "opusscript": "^0.0.8",
+    "play-dl": "^1.9.7"
   },
   "devDependencies": {
     "@sapphire/prettier-config": "^1.4.5",
@@ -32,7 +34,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
     "tsc-watch": "^6.0.0",
-    "tsup": "^6.6.3",
+    "tsup": "^7.2.0",
     "tsx": "^3.12.7",
     "typescript": "4.9.5"
   },

--- a/apps/music-bot/src/KarasuClient.ts
+++ b/apps/music-bot/src/KarasuClient.ts
@@ -36,8 +36,22 @@ export class KarasuClient extends SapphireClient {
 						cookie: process.env.YOUTUBE_COOKIE
 					}
 				}
-			}
+			},
+			skipFFmpeg: true
 		});
+
+		// this.player.events.on('willPlayTrack', (_, __, config, done) => {
+		// 	config.dispatcherConfig = {
+		// 		...config.dispatcherConfig,
+		// 		disableBiquad: true,
+		// 		disableEqualizer: true,
+		// 		disableFilters: true,
+		// 		disableResampler: true,
+		// 		disableVolume: true
+		// 	};
+
+		// 	done();
+		// });
 
 		if (!existsSync(this.recordingPath))
 			mkdirSync(this.recordingPath, {

--- a/apps/music-bot/src/commands/play.ts
+++ b/apps/music-bot/src/commands/play.ts
@@ -26,6 +26,7 @@ export class PlayCommand extends Command {
 		if (!query) return [];
 
 		const player = useMainPlayer();
+
 		const results = await player!.search(query!, {
 			requestedBy: interaction.user,
 			fallbackSearchEngine: QueryType.YOUTUBE_SEARCH
@@ -61,7 +62,7 @@ export class PlayCommand extends Command {
 		const query = interaction.options.getString('query');
 
 		if (permissions.clientToMember()) return interaction.reply({ content: permissions.clientToMember(), ephemeral: true });
-
+		await interaction.deferReply();
 		const results = await player!.search(query!, {
 			requestedBy: interaction.user,
 			fallbackSearchEngine: QueryType.YOUTUBE_SEARCH
@@ -72,8 +73,6 @@ export class PlayCommand extends Command {
 				content: `${this.container.client.dev.error} | **No** tracks were found for your query`,
 				ephemeral: true
 			});
-
-		await interaction.deferReply();
 
 		try {
 			const res = await player!.play(member.voice.channel!.id, results, {
@@ -88,8 +87,8 @@ export class PlayCommand extends Command {
 					leaveOnEnd: false,
 					pauseOnEmpty: true,
 					bufferingTimeout: 0,
-					volume: 50,
-					defaultFFmpegFilters: ['silenceremove']
+					volume: 50
+					// defaultFFmpegFilters: ['silenceremove']
 				}
 			});
 

--- a/apps/music-bot/tsconfig.json
+++ b/apps/music-bot/tsconfig.json
@@ -7,8 +7,8 @@
 		"tsBuildInfoFile": "dist/.tsbuildinfo",
 		"skipLibCheck": true,
 		"noImplicitAny": false,
-		"noImplicitReturns": false
+		"noImplicitReturns": false,
+		"ignoreDeprecations": "5.0"
 	},
 	"include": ["src"]
 }
- 

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -32,6 +32,7 @@
     "@mdx-js/loader": "^2.3.0",
     "@mdx-js/react": "^2.3.0",
     "@types/semver": "^7.5.0",
-    "react-icons": "^4.10.1"
+    "react-icons": "^4.10.1",
+    "tsup": "^7.2.0"
   }
 }

--- a/apps/website/src/pages/guide/_guides/faq/performance_optimization.mdx
+++ b/apps/website/src/pages/guide/_guides/faq/performance_optimization.mdx
@@ -6,27 +6,31 @@ Discord bots can experience lag and reduced performance, but there are effective
 
 Using a suitable hosting service is crucial for optimal bot performance. Free hosting services are not recommended, as they are often shared among multiple bots, leading to limited resources and potential lag. Instead, consider upgrading to a paid hosting service specifically optimized for Discord bots. Paid services generally offer better performance and more resources, allowing your bot to run smoothly even under heavy load.
 
-### 2. Shard Your Bot
+### 2. Avoid unnecessary filters
+
+FFmpeg filters are fine but other filters such as volume controller, equalizer, biquad, etc. can be performance heavy. If you don't need them, avoid using them. In other words, only enable the ones you need. You can also disable FFmpeg process by setting `skipFFmpeg: true`. Discord Player will skip ffmpeg transcoder if the stream is demuxable. You can still access non-ffmpeg filters while skipping ffmpeg process.
+
+### 3. Shard Your Bot
 
 JavaScript is single-threaded, and music bots can consume a lot of processing power, especially with numerous concurrent players. Sharding your bot involves dividing it into multiple processes, each with its own event loop. This distribution of processing power reduces the load on each shard, resulting in improved performance. Even if your bot doesn't meet the sharding requirements (2500 guilds), it's still beneficial to shard it, particularly for music bots handling at least 10-15 concurrent players.
 
-### 3. Use Shared Audio Player when possible
+### 4. Use Shared Audio Player when possible
 
 If your bot streams same audio across all guilds, you can use Shared Audio Player to reduce the load on your bot. Shared Audio Player allows you to stream the same audio to multiple guilds simultaneously, without having to create new player for each guild. Using Shared Audio Player can reduce cpu usage/bandwidth usage/memory usage. See [Shared Audio Player](/guide/examples/shared-audio-player) guide for more information.
 
-### 4. Optimize Operations with Asynchronicity
+### 5. Optimize Operations with Asynchronicity
 
 Avoid synchronous operations in your code, as they block the event loop and slow down event processing, leading to lag. Instead, prioritize asynchronous operations that don't block the event loop. By doing so, your bot can handle events more efficiently, resulting in better overall performance.
 
-### 5. Implement Caching
+### 6. Implement Caching
 
 Caching is a valuable technique to reduce the number of costly API calls, which can cause lag in your bot. Discord Player already implements in-memory caching for tracks, but you can customize and use your own cache to further enhance performance. By reducing API calls through caching, your bot can respond faster to user requests.
 
-### 6. Avoid Running Multiple Bots in the Same Process
+### 7. Avoid Running Multiple Bots in the Same Process
 
 Running multiple bots concurrently in the same process can negatively impact performance and may lead to memory issues. To avoid this, always run multiple bots in separate, isolated processes. This practice ensures that each bot operates independently and optimally.
 
-### 7. Use a Powerful Machine
+### 8. Use a Powerful Machine
 
 Selecting a powerful machine to host your bot is essential for handling larger player loads and enhancing performance. More powerful machines can cope with resource-intensive tasks, while sufficient RAM ensures your bot doesn't run out of memory, preventing crashes.
 

--- a/packages/adapter-local/package.json
+++ b/packages/adapter-local/package.json
@@ -24,6 +24,7 @@
     "url": "https://github.com/Androz2091/discord-player/issues"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   }
 }

--- a/packages/adapter-remote/package.json
+++ b/packages/adapter-remote/package.json
@@ -27,6 +27,7 @@
     "url": "https://github.com/Androz2091/discord-player/issues"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "discord-voip": "^0.1.2"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   }
 }

--- a/packages/discord-player/package.json
+++ b/packages/discord-player/package.json
@@ -70,6 +70,7 @@
     "discord-api-types": "^0.37.0",
     "discord.js": "^14.1.2",
     "opusscript": "^0.0.8",
+    "tsup": "^7.2.0",
     "typescript": "^4.7.4",
     "youtube-sr": "^4.3.4"
   },

--- a/packages/discord-player/src/Player.ts
+++ b/packages/discord-player/src/Player.ts
@@ -85,6 +85,7 @@ export class Player extends PlayerEventsEmitter<PlayerEvents> {
             lagMonitor: 30000,
             queryCache: options.queryCache === null ? null : options.queryCache || new QueryCache(this),
             useLegacyFFmpeg: false,
+            skipFFmpeg: false,
             ...options,
             ytdlOptions: {
                 highWaterMark: 1 << 25,

--- a/packages/discord-player/src/VoiceInterface/StreamDispatcher.ts
+++ b/packages/discord-player/src/VoiceInterface/StreamDispatcher.ts
@@ -35,6 +35,7 @@ export interface CreateStreamOps {
     volume?: number;
     disableResampler?: boolean;
     sampleRate?: number;
+    skipFFmpeg?: boolean;
 }
 
 export interface VoiceEvents {
@@ -374,6 +375,7 @@ class StreamDispatcher extends EventEmitter<VoiceEvents> {
     /**
      * Play stream
      * @param {AudioResource<Track>} [resource=this.audioResource] The audio resource to play
+     * @param {boolean} [opus=false] Whether or not to use opus
      * @returns {Promise<StreamDispatcher>}
      */
     async playStream(resource: AudioResource<Track> = this.audioResource!) {

--- a/packages/discord-player/src/extractors/BaseExtractor.ts
+++ b/packages/discord-player/src/extractors/BaseExtractor.ts
@@ -8,6 +8,14 @@ import type { RequestOptions } from 'http';
 import { Exceptions } from '../errors';
 import type { GuildQueueHistory } from '../manager';
 
+export type ExtractorStreamable =
+    | Readable
+    | string
+    | {
+          $fmt: string;
+          stream: Readable;
+      };
+
 export class BaseExtractor<T extends object = object> {
     /**
      * Identifier for this extractor
@@ -73,7 +81,7 @@ export class BaseExtractor<T extends object = object> {
      * Stream the given track
      * @param info The track to stream
      */
-    public async stream(info: Track): Promise<Readable | string> {
+    public async stream(info: Track): Promise<ExtractorStreamable> {
         void info;
         throw Exceptions.ERR_NOT_IMPLEMENTED(`${this.constructor.name}.stream()`);
     }
@@ -137,6 +145,13 @@ export class BaseExtractor<T extends object = object> {
      */
     public get routePlanner() {
         return this.context.player.routePlanner;
+    }
+
+    /**
+     * A flag to indicate `Demuxable` stream support for `opus`/`ogg/opus`/`webm/opus` formats.
+     */
+    public get supportsDemux() {
+        return !!this.context.player.options.skipFFmpeg;
     }
 }
 

--- a/packages/discord-player/src/manager/GuildQueueAudioFilters.ts
+++ b/packages/discord-player/src/manager/GuildQueueAudioFilters.ts
@@ -67,11 +67,20 @@ export class FFmpegFilterer<Meta = unknown> {
     #inputArgs: string[] = [];
     public constructor(public af: GuildQueueAudioFilters<Meta>) {}
 
+    /**
+     * Indicates whether ffmpeg may be skipped
+     */
+    public get skippable() {
+        return !!this.af.queue.player.options.skipFFmpeg;
+    }
+
     #setFilters(filters: Filters[]) {
         const { queue } = this.af;
-        const prev = this.#ffmpegFilters.slice();
+        // skip if filters are the same
+        if (filters.every((f) => this.#ffmpegFilters.includes(f)) && this.#ffmpegFilters.every((f) => filters.includes(f))) return Promise.resolve(false);
         const ignoreFilters = this.filters.some((ff) => ff === 'nightcore' || ff === 'vaporwave') && !filters.some((ff) => ff === 'nightcore' || ff === 'vaporwave');
         const seekTime = queue.node.getTimestamp(ignoreFilters)?.current.value || 0;
+        const prev = this.#ffmpegFilters.slice();
         this.#ffmpegFilters = [...new Set(filters)];
 
         return this.af.triggerReplay(seekTime).then((t) => {
@@ -264,6 +273,20 @@ export class GuildQueueAudioFilters<Meta = unknown> {
         }
     }
 
+    // TODO: enable this in the future
+    // public get ffmpeg(): FFmpegFilterer<Meta> | null {
+    //     if (this.queue.player.options.skipFFmpeg) {
+    //         if (this.#ffmpeg) this.#ffmpeg = null;
+    //         return null;
+    //     }
+
+    //     if (!this.#ffmpeg) {
+    //         this.#ffmpeg = new FFmpegFilterer<Meta>(this);
+    //     }
+
+    //     return this.#ffmpeg;
+    // }
+
     /**
      * Volume transformer
      */
@@ -326,7 +349,7 @@ export class AFilterGraph<Meta = unknown> {
     public constructor(public af: GuildQueueAudioFilters<Meta>) {}
 
     public get ffmpeg() {
-        return this.af.ffmpeg.filters;
+        return this.af.ffmpeg?.filters ?? [];
     }
 
     public get equalizer() {

--- a/packages/discord-player/src/manager/GuildQueuePlayerNode.ts
+++ b/packages/discord-player/src/manager/GuildQueuePlayerNode.ts
@@ -10,6 +10,8 @@ import { AsyncQueue } from '../utils/AsyncQueue';
 import { Exceptions } from '../errors';
 import { TypeUtil } from '../utils/TypeUtil';
 import { CreateStreamOps } from '../VoiceInterface/StreamDispatcher';
+import { ExtractorStreamable } from '../extractors/BaseExtractor';
+import * as prism from 'prism-media';
 
 export const FFMPEG_SRATE_REGEX = /asetrate=\d+\*(\d(\.\d)?)/;
 
@@ -38,8 +40,11 @@ export interface StreamConfig {
 
 export class GuildQueuePlayerNode<Meta = unknown> {
     #progress = 0;
+    #hasFFmpegOptimization = false;
     public tasksQueue = new AsyncQueue();
-    public constructor(public queue: GuildQueue<Meta>) {}
+    public constructor(public queue: GuildQueue<Meta>) {
+        this.#hasFFmpegOptimization = /libopus: (yes|true)/.test(this.queue.player.scanDeps());
+    }
 
     /**
      * If the player is currently in idle mode
@@ -211,6 +216,11 @@ export class GuildQueuePlayerNode<Meta = unknown> {
      */
     public async seek(duration: number) {
         if (!this.queue.currentTrack) return false;
+        if (duration === this.estimatedPlaybackTime) return true;
+        if (duration > this.totalDuration) {
+            return this.skip();
+        }
+        if (duration < 0) duration = 0;
         return await this.queue.filters.triggerReplay(duration);
     }
 
@@ -464,7 +474,7 @@ export class GuildQueuePlayerNode<Meta = unknown> {
 
             const streamSrc = {
                 error: null as Error | null,
-                stream: null as Readable | null
+                stream: null as ExtractorStreamable | null
             };
 
             await this.queue.onBeforeCreateStream?.(track, qt || 'arbitrary', this.queue).then(
@@ -510,23 +520,23 @@ export class GuildQueuePlayerNode<Meta = unknown> {
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const cookies = track.raw?.source === 'youtube' ? (<any>this.queue.player.options.ytdlOptions?.requestOptions)?.headers?.cookie : undefined;
-            const createStreamConfig = {
-                disableBiquad: this.queue.options.disableBiquad,
-                disableEqualizer: this.queue.options.disableEqualizer,
-                disableVolume: this.queue.options.disableVolume,
-                disableFilters: this.queue.options.disableFilterer,
-                disableResampler: this.queue.options.disableResampler,
-                sampleRate: typeof this.queue.options.resampler === 'number' && this.queue.options.resampler > 0 ? this.queue.options.resampler : undefined,
-                biquadFilter: this.queue.filters._lastFiltersCache.biquad || undefined,
-                eq: this.queue.filters._lastFiltersCache.equalizer,
-                defaultFilters: this.queue.filters._lastFiltersCache.filters,
-                volume: this.queue.filters._lastFiltersCache.volume,
-                data: track,
-                type: StreamType.Raw
-            };
 
             const trackStreamConfig: StreamConfig = {
-                dispatcherConfig: createStreamConfig,
+                dispatcherConfig: {
+                    disableBiquad: this.queue.options.disableBiquad,
+                    disableEqualizer: this.queue.options.disableEqualizer,
+                    disableVolume: this.queue.options.disableVolume,
+                    disableFilters: this.queue.options.disableFilterer,
+                    disableResampler: this.queue.options.disableResampler,
+                    sampleRate: typeof this.queue.options.resampler === 'number' && this.queue.options.resampler > 0 ? this.queue.options.resampler : undefined,
+                    biquadFilter: this.queue.filters._lastFiltersCache.biquad || undefined,
+                    eq: this.queue.filters._lastFiltersCache.equalizer,
+                    defaultFilters: this.queue.filters._lastFiltersCache.filters,
+                    volume: this.queue.filters._lastFiltersCache.volume,
+                    data: track,
+                    type: StreamType.Raw,
+                    skipFFmpeg: this.queue.player.options.skipFFmpeg
+                },
                 playerConfig: options
             };
 
@@ -542,7 +552,65 @@ export class GuildQueuePlayerNode<Meta = unknown> {
 
             await donePromise;
 
-            const pcmStream = this.#createFFmpegStream(streamSrc.stream, track, options.seek ?? 0, cookies);
+            // prettier-ignore
+            const daspDisabled = [
+                trackStreamConfig.dispatcherConfig.disableBiquad,
+                trackStreamConfig.dispatcherConfig.disableEqualizer,
+                trackStreamConfig.dispatcherConfig.disableFilters,
+                trackStreamConfig.dispatcherConfig.disableResampler,
+                trackStreamConfig.dispatcherConfig.disableVolume
+            ].every((e) => !!e === true);
+
+            const needsFilters = !!trackStreamConfig.playerConfig.seek || !!this.queue.filters.ffmpeg.args.length;
+            const shouldSkipFFmpeg = !!trackStreamConfig.dispatcherConfig.skipFFmpeg && !needsFilters;
+
+            let finalStream: Readable;
+
+            const demuxable = (fmt: string) => [StreamType.Opus, StreamType.WebmOpus, StreamType.OggOpus].includes(fmt as StreamType);
+
+            // skip ffmpeg when possible
+            if (shouldSkipFFmpeg && !(streamSrc.stream instanceof Readable) && typeof streamSrc.stream !== 'string' && demuxable(streamSrc.stream.$fmt)) {
+                const { $fmt, stream } = streamSrc.stream;
+                const shouldPCM = !daspDisabled;
+
+                if (this.queue.hasDebugger) this.queue.debug(`skipFFmpeg is set to true and stream is demuxable, creating stream with type ${shouldPCM ? 'pcm' : 'opus'}`);
+
+                // prettier-ignore
+                const opusStream = $fmt === StreamType.Opus ?
+                    stream :
+                    $fmt === StreamType.OggOpus ?
+                    stream.pipe(new prism.opus.OggDemuxer()) :
+                    stream.pipe(new prism.opus.WebmDemuxer());
+
+                if (shouldPCM) {
+                    // if we have any filters enabled, we need to decode the opus stream to pcm
+                    finalStream = opusStream.pipe(
+                        new prism.opus.Decoder({
+                            channels: 2,
+                            frameSize: 960,
+                            rate: 48000
+                        })
+                    );
+                    trackStreamConfig.dispatcherConfig.type = StreamType.Raw;
+                } else {
+                    finalStream = opusStream;
+                    trackStreamConfig.dispatcherConfig.type = StreamType.Opus;
+                }
+            } else {
+                // const opus = daspDisabled && this.#hasFFmpegOptimization;
+                // if (opus && this.queue.hasDebugger) this.queue.debug('Disabling PCM output since all filters are disabled and opus encoding is supported...');
+
+                finalStream = this.#createFFmpegStream(
+                    streamSrc.stream instanceof Readable || typeof streamSrc.stream === 'string' ? streamSrc.stream : streamSrc.stream.stream,
+                    track,
+                    options.seek ?? 0,
+                    cookies
+                    // opus
+                );
+                trackStreamConfig.dispatcherConfig.type = StreamType.Raw;
+                // FIXME: OggOpus results in static noise
+                // trackStreamConfig.dispatcherConfig.type = opus ? StreamType.OggOpus : StreamType.Raw;
+            }
 
             if (options.transitionMode) {
                 if (this.queue.hasDebugger) this.queue.debug(`Transition mode detected, player will wait for buffering timeout to expire (Timeout: ${this.queue.options.bufferingTimeout}ms)`);
@@ -552,7 +620,7 @@ export class GuildQueuePlayerNode<Meta = unknown> {
 
             if (this.queue.hasDebugger) this.queue.debug(`Preparing final stream config: ${JSON.stringify(trackStreamConfig, null, 2)}`);
 
-            const resource = await this.queue.dispatcher.createStream(pcmStream, createStreamConfig);
+            const resource = await this.queue.dispatcher.createStream(finalStream, trackStreamConfig.dispatcherConfig);
 
             this.queue.setTransitioning(!!options.transitionMode);
 
@@ -605,12 +673,12 @@ export class GuildQueuePlayerNode<Meta = unknown> {
         return streamInfo;
     }
 
-    #createFFmpegStream(stream: Readable | string, track: Track, seek = 0, cookies?: string) {
+    #createFFmpegStream(stream: Readable | string, track: Track, seek = 0, cookies?: string, opus?: boolean) {
         const ffmpegStream = this.queue.filters.ffmpeg
             .createStream(stream, {
                 encoderArgs: this.queue.filters.ffmpeg.args,
                 seek: seek / 1000,
-                fmt: 's16le',
+                fmt: opus ? 'opus' : 's16le',
                 cookies,
                 useLegacyFFmpeg: !!this.queue.player.options.useLegacyFFmpeg
             })

--- a/packages/discord-player/src/types/types.ts
+++ b/packages/discord-player/src/types/types.ts
@@ -1,4 +1,4 @@
-import { Snowflake, User, UserResolvable, VoiceState } from 'discord.js';
+import { User, UserResolvable, VoiceState } from 'discord.js';
 import { GuildQueue } from '../manager';
 import { Track } from '../fabric/Track';
 import { Playlist } from '../fabric/Playlist';
@@ -17,7 +17,7 @@ export interface PlayerSearchResult {
 }
 
 /**
- * @typedef {AudioFilters} QueueFilters
+ * Represents FFmpeg filters
  */
 export interface QueueFilters {
     bassboost_low?: boolean;
@@ -64,74 +64,115 @@ export interface QueueFilters {
  * - spotify
  * - apple_music
  * - arbitrary
- * @typedef {string} TrackSource
  */
 export type TrackSource = 'soundcloud' | 'youtube' | 'spotify' | 'apple_music' | 'arbitrary';
 
-/**
- * @typedef {object} RawTrackData
- * @property {string} title The title
- * @property {string} description The description
- * @property {string} author The author
- * @property {string} url The url
- * @property {string} thumbnail The thumbnail
- * @property {string} duration The duration
- * @property {number} views The views
- * @property {User} requestedBy The user who requested this track
- * @property {Playlist} [playlist] The playlist
- * @property {TrackSource} [source="arbitrary"] The source
- * @property {any} [engine] The engine
- * @property {boolean} [live] If this track is live
- * @property {any} [raw] The raw data
- */
 export interface RawTrackData {
+    /**
+     * The title
+     */
     title: string;
+    /**
+     * The description
+     */
     description: string;
+    /**
+     * The author
+     */
     author: string;
+    /**
+     * The url
+     */
     url: string;
+    /**
+     * The thumbnail
+     */
     thumbnail: string;
+    /**
+     * The duration
+     */
     duration: string;
+    /**
+     * The duration in ms
+     */
     views: number;
+    /**
+     * The user who requested this track
+     */
     requestedBy?: User | null;
+    /**
+     * The playlist
+     */
     playlist?: Playlist;
+    /**
+     * The source
+     */
     source?: TrackSource;
+    /**
+     * The engine
+     */
     engine?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    /**
+     * If this track is live
+     */
     live?: boolean;
+    /**
+     * The raw data
+     */
     raw?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    /**
+     * The query type
+     */
     queryType?: SearchQueryType;
 }
 
-/**
- * @typedef {object} TimeData
- * @property {number} days Time in days
- * @property {number} hours Time in hours
- * @property {number} minutes Time in minutes
- * @property {number} seconds Time in seconds
- */
 export interface TimeData {
+    /**
+     * Time in days
+     */
     days: number;
+    /**
+     * Time in hours
+     */
     hours: number;
+    /**
+     * Time in minutes
+     */
     minutes: number;
+    /**
+     * Time in seconds
+     */
     seconds: number;
 }
 
-/**
- * @typedef {object} PlayerProgressbarOptions
- * @property {boolean} [timecodes] If it should render time codes
- * @property {boolean} [queue] If it should create progress bar for the whole queue
- * @property {number} [length] The bar length
- * @property {string} [leftChar] The elapsed time track
- * @property {string} [rightChar] The remaining time track
- * @property {string} [separator] The separation between timestamp and line
- * @property {string} [indicator] The indicator
- */
 export interface PlayerProgressbarOptions {
+    /**
+     * If it should render time codes
+     */
     timecodes?: boolean;
+    /**
+     * If it should create progress bar for the whole queue
+     */
     length?: number;
+    /**
+     * The bar length
+     */
     leftChar?: string;
+    /**
+     * The elapsed time track
+     */
     rightChar?: string;
+    /**
+     * The remaining time track
+     */
     separator?: string;
+    /**
+     * The separation between timestamp and line
+     */
     indicator?: string;
+    /**
+     * The indicator
+     */
     queue?: boolean;
 }
 
@@ -206,38 +247,52 @@ export enum PlayerEvent {
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-/**
- * @typedef {object} PlayOptions
- * @property {boolean} [filtersUpdate=false] If this play was triggered for filters update
- * @property {string[]} [encoderArgs=[]] FFmpeg args passed to encoder
- * @property {number} [seek] Time to seek to before playing
- * @property {boolean} [immediate=false] If it should start playing the provided track immediately
- */
 export interface PlayOptions {
+    /**
+     * If this play was triggered for filters update
+     */
     filtersUpdate?: boolean;
+    /**
+     * FFmpeg args passed to encoder
+     */
     encoderArgs?: string[];
+    /**
+     * Time to seek to before playing
+     */
     seek?: number;
+    /**
+     * If it should start playing the provided track immediately
+     */
     immediate?: boolean;
 }
 
 export type QueryExtractorSearch = `ext:${string}`;
 
-/**
- * @typedef {object} SearchOptions
- * @property {UserResolvable} requestedBy The user who requested this search
- * @property {typeof QueryType|string} [searchEngine='auto'] The query search engine, can be extractor name to target specific one (custom)
- * @property {string[]} [blockExtractors[]] List of the extractors to block
- * @property {boolean} [ignoreCache] If it should ignore query cache lookup
- * @property {SearchQueryType} [fallbackSearchEngine='autoSearch'] Fallback search engine to use
- * @property {any} [requestOptions] The request options
- */
 export interface SearchOptions {
+    /**
+     * The user who requested this search
+     */
     requestedBy?: UserResolvable;
+    /**
+     * The query search engine, can be extractor name to target specific one (custom)
+     */
     searchEngine?: SearchQueryType | QueryExtractorSearch;
+    /**
+     * List of the extractors to block
+     */
     blockExtractors?: string[];
+    /**
+     * If it should ignore query cache lookup
+     */
     ignoreCache?: boolean;
+    /**
+     * Fallback search engine to use
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     requestOptions?: any;
+    /**
+     * Fallback search engine to use
+     */
     fallbackSearchEngine?: (typeof QueryType)[keyof typeof QueryType];
 }
 
@@ -247,127 +302,221 @@ export interface SearchOptions {
  * - TRACK
  * - QUEUE
  * - AUTOPLAY
- * @typedef {number} QueueRepeatMode
  */
 export enum QueueRepeatMode {
+    /**
+     * Disable repeat mode.
+     */
     OFF = 0,
+    /**
+     * Repeat the current track.
+     */
     TRACK = 1,
+    /**
+     * Repeat the entire queue.
+     */
     QUEUE = 2,
+    /**
+     * When last track ends, play similar tracks in the future if queue is empty.
+     */
     AUTOPLAY = 3
 }
 
-/**
- * @typedef {object} PlaylistInitData
- * @property {Track[]} tracks The tracks of this playlist
- * @property {string} title The playlist title
- * @property {string} description The description
- * @property {string} thumbnail The thumbnail
- * @property {album|playlist} type The playlist type: `album` | `playlist`
- * @property {TrackSource} source The playlist source
- * @property {object} author The playlist author
- * @property {string} [author.name] The author name
- * @property {string} [author.url] The author url
- * @property {string} id The playlist id
- * @property {string} url The playlist url
- * @property {any} [rawPlaylist] The raw playlist data
- */
 export interface PlaylistInitData {
+    /**
+     * The tracks of this playlist
+     */
     tracks: Track[];
+    /**
+     * The playlist title
+     */
     title: string;
+    /**
+     * The description
+     */
     description: string;
+    /**
+     * The thumbnail
+     */
     thumbnail: string;
+    /**
+     * The playlist type: `album` | `playlist`
+     */
     type: 'album' | 'playlist';
+    /**
+     * The playlist source
+     */
     source: TrackSource;
+    /**
+     * The playlist author
+     */
     author: {
+        /**
+         * The author name
+         */
         name: string;
+        /**
+         * The author url
+         */
         url: string;
     };
+    /**
+     * The playlist id
+     */
     id: string;
+    /**
+     * The playlist url
+     */
     url: string;
+    /**
+     * The raw playlist data
+     */
     rawPlaylist?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-/**
- * @typedef {object} TrackJSON
- * @property {string} title The track title
- * @property {string} description The track description
- * @property {string} author The author
- * @property {string} url The url
- * @property {string} thumbnail The thumbnail
- * @property {string} duration The duration
- * @property {number} durationMS The duration in ms
- * @property {number} views The views count
- * @property {Snowflake} requestedBy The id of the user who requested this track
- * @property {PlaylistJSON} [playlist] The playlist info (if any)
- */
 export interface TrackJSON {
-    id: Snowflake;
+    /**
+     * The track id
+     */
+    id: string;
+    /**
+     * The track title
+     */
     title: string;
+    /**
+     * The track description
+     */
     description: string;
+    /**
+     * The track author
+     */
     author: string;
+    /**
+     * The track url
+     */
     url: string;
+    /**
+     * The track thumbnail
+     */
     thumbnail: string;
+    /**
+     * The track duration
+     */
     duration: string;
+    /**
+     * The track duration in ms
+     */
     durationMS: number;
+    /**
+     * The track views
+     */
     views: number;
-    requestedBy: Snowflake;
+    /**
+     * The user id who requested this track
+     */
+    requestedBy: string;
+    /**
+     * The playlist info (if any)
+     */
     playlist?: PlaylistJSON;
 }
 
-/**
- * @typedef {object} PlaylistJSON
- * @property {string} id The playlist id
- * @property {string} url The playlist url
- * @property {string} title The playlist title
- * @property {string} description The playlist description
- * @property {string} thumbnail The thumbnail
- * @property {album|playlist} type The playlist type: `album` | `playlist`
- * @property {TrackSource} source The track source
- * @property {object} author The playlist author
- * @property {string} [author.name] The author name
- * @property {string} [author.url] The author url
- * @property {TrackJSON[]} tracks The tracks data (if any)
- */
 export interface PlaylistJSON {
+    /**
+     * The playlist id
+     */
     id: string;
+    /**
+     * The playlist url
+     */
     url: string;
+    /**
+     * The playlist title
+     */
     title: string;
+    /**
+     * The playlist description
+     */
     description: string;
+    /**
+     * The thumbnail
+     */
     thumbnail: string;
+    /**
+     * The playlist type: `album` | `playlist`
+     */
     type: 'album' | 'playlist';
+    /**
+     * The track source
+     */
     source: TrackSource;
+    /**
+     * The playlist author
+     */
     author: {
+        /**
+         * The author name
+         */
         name: string;
+        /**
+         * The author url
+         */
         url: string;
     };
+    /**
+     * The tracks data (if any)
+     */
     tracks: TrackJSON[];
 }
 
-/**
- * @typedef {object} PlayerInitOptions
- * @property {YTDLDownloadOptions} [ytdlOptions] The options passed to `ytdl-core`
- * @property {number} [connectionTimeout=20000] The voice connection timeout
- * @property {boolean} [lagMonitor=30000] Time in ms to re-monitor event loop lag
- * @property {boolean} [lockVoiceStateHandler] Prevent voice state handler from being overridden
- * @property {string[]} [blockExtractors] List of extractors to disable querying metadata from
- * @property {string[]} [blockStreamFrom] List of extractors to disable streaming from
- * @property {QueryCache | null} [queryCache] Query cache provider
- * @property {boolean} [ignoreInstance] Ignore player instance
- * @property {boolean} [useLegacyFFmpeg] Use legacy version of ffmpeg
- * @property {BridgeProvider} [bridgeProvider] Set bridge provider
- * @property {object} [ipconfig] IP rotator config
- */
 export interface PlayerInitOptions {
+    /**
+     * The options passed to `ytdl-core`.
+     */
     ytdlOptions?: downloadOptions;
+    /**
+     * The voice connection timeout
+     */
     connectionTimeout?: number;
+    /**
+     * Time in ms to re-monitor event loop lag
+     */
     lagMonitor?: number;
+    /**
+     * Prevent voice state handler from being overridden
+     */
     lockVoiceStateHandler?: boolean;
+    /**
+     * List of extractors to disable querying metadata from
+     */
     blockExtractors?: string[];
+    /**
+     * List of extractors to disable streaming from
+     */
     blockStreamFrom?: string[];
+    /**
+     * Query cache provider
+     */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     queryCache?: QueryCacheProvider<any> | null;
+    /**
+     * Ignore player instance
+     */
     ignoreInstance?: boolean;
+    /**
+     * Use legacy version of ffmpeg
+     */
     useLegacyFFmpeg?: boolean;
+    /**
+     * Set bridge provider
+     */
     bridgeProvider?: BridgeProvider;
+    /**
+     * IP rotator config
+     */
     ipconfig?: IPRotationConfig;
+    /**
+     * Skip ffmpeg process when possible
+     */
+    skipFFmpeg?: boolean;
 }

--- a/packages/discord-player/src/utils/FFmpegStream.ts
+++ b/packages/discord-player/src/utils/FFmpegStream.ts
@@ -14,18 +14,30 @@ export interface FFmpegStreamOptions {
 const getFFmpegProvider = (legacy = false) => (legacy ? (prism as typeof prism & { default: typeof prism }).default?.FFmpeg || prism.FFmpeg : FFmpeg);
 
 export function FFMPEG_ARGS_STRING(stream: string, fmt?: string, cookies?: string) {
-    // prettier-ignore
     const args = [
-        "-reconnect", "1",
-        "-reconnect_streamed", "1",
-        "-reconnect_delay_max", "5",
-        "-i", stream,
-        "-analyzeduration", "0",
-        "-loglevel", "0",
-        "-f", `${typeof fmt === "string" ? fmt : "s16le"}`,
-        "-ar", "48000",
-        "-ac", "2"
+        '-reconnect',
+        '1',
+        '-reconnect_streamed',
+        '1',
+        '-reconnect_delay_max',
+        '5',
+        '-i',
+        stream,
+        '-analyzeduration',
+        '0',
+        '-loglevel',
+        '0',
+        '-ar',
+        '48000',
+        '-ac',
+        '2',
+        '-f',
+        `${typeof fmt === 'string' ? fmt : 's16le'}`
     ];
+
+    if (fmt === 'opus') {
+        args.push('-acodec', 'libopus');
+    }
 
     if (typeof cookies === 'string') {
         // https://ffmpeg.org/ffmpeg-protocols.html#HTTP-Cookies
@@ -37,13 +49,24 @@ export function FFMPEG_ARGS_STRING(stream: string, fmt?: string, cookies?: strin
 
 export function FFMPEG_ARGS_PIPED(fmt?: string) {
     // prettier-ignore
-    return [
-        "-analyzeduration", "0",
-        "-loglevel", "0",
-        "-f", `${typeof fmt === "string" ? fmt : "s16le"}`,
-        "-ar", "48000",
-        "-ac", "2"
+    const args = [
+        '-analyzeduration',
+        '0',
+        '-loglevel',
+        '0',
+        '-ar',
+        '48000',
+        '-ac',
+        '2',
+        '-f',
+        `${typeof fmt === 'string' ? fmt : 's16le'}`,
     ];
+
+    if (fmt === 'opus') {
+        args.push('-acodec', 'libopus');
+    }
+
+    return args;
 }
 
 /**

--- a/packages/downloader/package.json
+++ b/packages/downloader/package.json
@@ -34,7 +34,8 @@
     "url": "https://github.com/Androz2091/discord-player/issues"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   },
   "dependencies": {
     "youtube-dl-exec": "^2.1.11"

--- a/packages/equalizer/package.json
+++ b/packages/equalizer/package.json
@@ -41,7 +41,8 @@
     "url": "https://github.com/Androz2091/discord-player/issues"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts",

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -40,6 +40,7 @@
     "discord-player": "workspace:^",
     "mediaplex": "^0.0.7",
     "play-dl": "^1.9.6",
+    "tsup": "^7.2.0",
     "youtube-ext": "^1.1.14",
     "yt-stream": "^1.4.8",
     "ytdl-core": "^4.11.4"

--- a/packages/extractor/src/extractors/AppleMusicExtractor.ts
+++ b/packages/extractor/src/extractors/AppleMusicExtractor.ts
@@ -1,4 +1,4 @@
-import { ExtractorInfo, ExtractorSearchContext, GuildQueueHistory, Playlist, QueryType, SearchQueryType, Track, Util } from 'discord-player';
+import { ExtractorInfo, ExtractorSearchContext, ExtractorStreamable, GuildQueueHistory, Playlist, QueryType, SearchQueryType, Track, Util } from 'discord-player';
 import { AppleMusic } from '../internal';
 import { Readable } from 'stream';
 import { StreamFN, pullYTMetadata } from './common/helper';
@@ -237,7 +237,7 @@ export class AppleMusicExtractor extends BridgedExtractor<AppleMusicExtractorIni
         }
     }
 
-    public async stream(info: Track): Promise<string | Readable> {
+    public async stream(info: Track): Promise<ExtractorStreamable> {
         if (this._stream) {
             const stream = await this._stream(info.url, this);
             if (typeof stream === 'string') return stream;

--- a/packages/extractor/src/extractors/SpotifyExtractor.ts
+++ b/packages/extractor/src/extractors/SpotifyExtractor.ts
@@ -1,4 +1,4 @@
-import { ExtractorInfo, ExtractorSearchContext, Playlist, QueryType, SearchQueryType, Track, Util } from 'discord-player';
+import { ExtractorInfo, ExtractorSearchContext, ExtractorStreamable, Playlist, QueryType, SearchQueryType, Track, Util } from 'discord-player';
 import type { Readable } from 'stream';
 import { StreamFN, fetch, pullYTMetadata } from './common/helper';
 import spotify, { Spotify, SpotifyAlbum, SpotifyPlaylist, SpotifySong } from 'spotify-url-info';
@@ -341,7 +341,7 @@ export class SpotifyExtractor extends BridgedExtractor<SpotifyExtractorInit> {
         }
     }
 
-    public async stream(info: Track): Promise<string | Readable> {
+    public async stream(info: Track): Promise<ExtractorStreamable> {
         if (this._stream) {
             const stream = await this._stream(info.url, this);
             if (typeof stream === 'string') return stream;

--- a/packages/extractor/src/extractors/YoutubeExtractor.ts
+++ b/packages/extractor/src/extractors/YoutubeExtractor.ts
@@ -10,7 +10,8 @@ import {
     QueryType,
     SearchQueryType,
     Track,
-    Util
+    Util,
+    ExtractorStreamable
 } from 'discord-player';
 
 import { StreamFN, YouTubeLibs, loadYtdl, makeYTSearch } from './common/helper';
@@ -244,7 +245,7 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
         return { playlist: null, tracks: [] };
     }
 
-    public async stream(info: Track): Promise<Readable | string> {
+    public async stream(info: Track): Promise<ExtractorStreamable> {
         if (!this._stream) {
             throw new Error(`Could not find youtube streaming library. Install one of ${YouTubeLibs.join(', ')}`);
         }
@@ -252,7 +253,7 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
         let url = info.url;
         url = url.includes('youtube.com') ? url.replace(/(m(usic)?|gaming)\./, '') : url;
 
-        return this._stream(url, this);
+        return this._stream(url, this, this.supportsDemux);
     }
 
     public static validateURL(link: string) {

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@discord-player/tsconfig": "workspace:^",
-    "@types/node": "^20.3.1"
+    "@types/node": "^20.3.1",
+    "tsup": "^7.2.0"
   }
 }

--- a/packages/opus/package.json
+++ b/packages/opus/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@discord-player/tsconfig": "workspace:^",
-    "@evan/opus": "^1.0.2"
+    "@evan/opus": "^1.0.2",
+    "tsup": "^7.2.0"
   }
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -17,5 +17,8 @@
   },
   "bugs": {
     "url": "https://github.com/Androz2091/discord-player/issues"
+  },
+  "devDependencies": {
+    "tsup": "^7.2.0"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -34,7 +34,8 @@
     "@discordjs/collection": "^1.1.0"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -36,7 +36,8 @@
     "url": "https://github.com/Androz2091/discord-player/issues"
   },
   "devDependencies": {
-    "@discord-player/tsconfig": "workspace:^"
+    "@discord-player/tsconfig": "workspace:^",
+    "tsup": "^7.2.0"
   },
   "dependencies": {
     "@discord-player/utils": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,7 @@ __metadata:
   resolution: "@discord-player/adapter-local@workspace:packages/adapter-local"
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -53,6 +54,7 @@ __metadata:
   resolution: "@discord-player/adapter-remote@workspace:packages/adapter-remote"
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -64,6 +66,7 @@ __metadata:
     "@discord-player/utils": "workspace:^"
     discord-api-types: ^0.37.2
     discord-voip: ^0.1.2
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -93,6 +96,7 @@ __metadata:
   resolution: "@discord-player/downloader@workspace:packages/downloader"
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
+    tsup: ^7.2.0
     youtube-dl-exec: ^2.1.11
   languageName: unknown
   linkType: soft
@@ -102,6 +106,7 @@ __metadata:
   resolution: "@discord-player/equalizer@workspace:packages/equalizer"
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -122,6 +127,7 @@ __metadata:
     reverbnation-scraper: ^2.0.0
     soundcloud.ts: ^0.5.2
     spotify-url-info: ^3.2.6
+    tsup: ^7.2.0
     youtube-ext: ^1.1.14
     youtube-sr: ^4.3.4
     yt-stream: ^1.4.8
@@ -135,6 +141,7 @@ __metadata:
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
     "@types/node": ^20.3.1
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -144,12 +151,15 @@ __metadata:
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
     "@evan/opus": ^1.0.2
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
 "@discord-player/tsconfig@workspace:^, @discord-player/tsconfig@workspace:packages/tsconfig":
   version: 0.0.0-use.local
   resolution: "@discord-player/tsconfig@workspace:packages/tsconfig"
+  dependencies:
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -159,6 +169,7 @@ __metadata:
   dependencies:
     "@discord-player/tsconfig": "workspace:^"
     "@discordjs/collection": ^1.1.0
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -169,6 +180,7 @@ __metadata:
     "@discord-player/tsconfig": "workspace:^"
     "@discord-player/utils": "workspace:^"
     discord-voip: ^0.1.2
+    tsup: ^7.2.0
   languageName: unknown
   linkType: soft
 
@@ -291,6 +303,19 @@ __metadata:
     tough-cookie: ^4.1.3
     undici: ^5.23.0
   checksum: ee7b4ced517edb19dde8b8e17cb6002e6139ddc3efb43bcbd271b3625ba97b4e7281335c00df8ba04d56f2a3324eb57dbbd60a8b5b292310617f1c70ce68946a
+  languageName: node
+  linkType: hard
+
+"@distube/ytdl-core@npm:^4.13.2":
+  version: 4.13.2
+  resolution: "@distube/ytdl-core@npm:4.13.2"
+  dependencies:
+    http-cookie-agent: ^5.0.4
+    m3u8stream: ^0.8.6
+    sax: ^1.2.4
+    tough-cookie: ^4.1.3
+    undici: ^5.25.2
+  checksum: f8b73ab5f537b779070cbe39583d894742ef72653d231a0bc30b1db1b37e4d16754bcce3ac246e4d490a6b35a0bd86c632517087c29acd6143ba447fc53202e8
   languageName: node
   linkType: hard
 
@@ -902,6 +927,13 @@ __metadata:
   version: 1.0.2
   resolution: "@evan/opus@npm:1.0.2"
   checksum: 5473155e79eb99a6bf5d2b35cbad5b2ff687e9aa5b1e2a7c15bd701eb3eb3986b6452079650823e8211727d8f033a6be86484e10c87f7eef5ebbbbfb7e10c928
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@fastify/busboy@npm:2.0.0"
+  checksum: 41879937ce1dee6421ef9cd4da53239830617e1f0bb7a0e843940772cd72827205d05e518af6adabe6e1ea19301285fff432b9d11bad01a531e698bea95c781b
   languageName: node
   linkType: hard
 
@@ -4739,6 +4771,7 @@ __metadata:
     ip: ^1.1.8
     libsodium-wrappers: ^0.7.10
     opusscript: ^0.0.8
+    tsup: ^7.2.0
     typescript: ^4.7.4
     youtube-sr: ^4.3.4
   peerDependencies:
@@ -5126,83 +5159,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.17.6, esbuild@npm:~0.17.6":
-  version: 0.17.19
-  resolution: "esbuild@npm:0.17.19"
-  dependencies:
-    "@esbuild/android-arm": 0.17.19
-    "@esbuild/android-arm64": 0.17.19
-    "@esbuild/android-x64": 0.17.19
-    "@esbuild/darwin-arm64": 0.17.19
-    "@esbuild/darwin-x64": 0.17.19
-    "@esbuild/freebsd-arm64": 0.17.19
-    "@esbuild/freebsd-x64": 0.17.19
-    "@esbuild/linux-arm": 0.17.19
-    "@esbuild/linux-arm64": 0.17.19
-    "@esbuild/linux-ia32": 0.17.19
-    "@esbuild/linux-loong64": 0.17.19
-    "@esbuild/linux-mips64el": 0.17.19
-    "@esbuild/linux-ppc64": 0.17.19
-    "@esbuild/linux-riscv64": 0.17.19
-    "@esbuild/linux-s390x": 0.17.19
-    "@esbuild/linux-x64": 0.17.19
-    "@esbuild/netbsd-x64": 0.17.19
-    "@esbuild/openbsd-x64": 0.17.19
-    "@esbuild/sunos-x64": 0.17.19
-    "@esbuild/win32-arm64": 0.17.19
-    "@esbuild/win32-ia32": 0.17.19
-    "@esbuild/win32-x64": 0.17.19
-  dependenciesMeta:
-    "@esbuild/android-arm":
-      optional: true
-    "@esbuild/android-arm64":
-      optional: true
-    "@esbuild/android-x64":
-      optional: true
-    "@esbuild/darwin-arm64":
-      optional: true
-    "@esbuild/darwin-x64":
-      optional: true
-    "@esbuild/freebsd-arm64":
-      optional: true
-    "@esbuild/freebsd-x64":
-      optional: true
-    "@esbuild/linux-arm":
-      optional: true
-    "@esbuild/linux-arm64":
-      optional: true
-    "@esbuild/linux-ia32":
-      optional: true
-    "@esbuild/linux-loong64":
-      optional: true
-    "@esbuild/linux-mips64el":
-      optional: true
-    "@esbuild/linux-ppc64":
-      optional: true
-    "@esbuild/linux-riscv64":
-      optional: true
-    "@esbuild/linux-s390x":
-      optional: true
-    "@esbuild/linux-x64":
-      optional: true
-    "@esbuild/netbsd-x64":
-      optional: true
-    "@esbuild/openbsd-x64":
-      optional: true
-    "@esbuild/sunos-x64":
-      optional: true
-    "@esbuild/win32-arm64":
-      optional: true
-    "@esbuild/win32-ia32":
-      optional: true
-    "@esbuild/win32-x64":
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: ac11b1a5a6008e4e37ccffbd6c2c054746fc58d0ed4a2f9ee643bd030cfcea9a33a235087bc777def8420f2eaafb3486e76adb7bdb7241a9143b43a69a10afd8
-  languageName: node
-  linkType: hard
-
 "esbuild@npm:^0.18.2":
   version: 0.18.20
   resolution: "esbuild@npm:0.18.20"
@@ -5277,6 +5233,83 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 5d253614e50cdb6ec22095afd0c414f15688e7278a7eb4f3720a6dd1306b0909cf431e7b9437a90d065a31b1c57be60130f63fe3e8d0083b588571f31ee6ec7b
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:~0.17.6":
+  version: 0.17.19
+  resolution: "esbuild@npm:0.17.19"
+  dependencies:
+    "@esbuild/android-arm": 0.17.19
+    "@esbuild/android-arm64": 0.17.19
+    "@esbuild/android-x64": 0.17.19
+    "@esbuild/darwin-arm64": 0.17.19
+    "@esbuild/darwin-x64": 0.17.19
+    "@esbuild/freebsd-arm64": 0.17.19
+    "@esbuild/freebsd-x64": 0.17.19
+    "@esbuild/linux-arm": 0.17.19
+    "@esbuild/linux-arm64": 0.17.19
+    "@esbuild/linux-ia32": 0.17.19
+    "@esbuild/linux-loong64": 0.17.19
+    "@esbuild/linux-mips64el": 0.17.19
+    "@esbuild/linux-ppc64": 0.17.19
+    "@esbuild/linux-riscv64": 0.17.19
+    "@esbuild/linux-s390x": 0.17.19
+    "@esbuild/linux-x64": 0.17.19
+    "@esbuild/netbsd-x64": 0.17.19
+    "@esbuild/openbsd-x64": 0.17.19
+    "@esbuild/sunos-x64": 0.17.19
+    "@esbuild/win32-arm64": 0.17.19
+    "@esbuild/win32-ia32": 0.17.19
+    "@esbuild/win32-x64": 0.17.19
+  dependenciesMeta:
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: ac11b1a5a6008e4e37ccffbd6c2c054746fc58d0ed4a2f9ee643bd030cfcea9a33a235087bc777def8420f2eaafb3486e76adb7bdb7241a9143b43a69a10afd8
   languageName: node
   linkType: hard
 
@@ -8681,6 +8714,7 @@ __metadata:
     "@discord-player/extractor": "workspace:^"
     "@discord-player/utils": "workspace:^"
     "@discordjs/opus": ^0.9.0
+    "@distube/ytdl-core": ^4.13.2
     "@sapphire/discord.js-utilities": ^6.0.3
     "@sapphire/duration": ^1.0.0
     "@sapphire/framework": ^4.2.1
@@ -8700,9 +8734,10 @@ __metadata:
     mediaplex: ^0.0.2
     npm-run-all: ^4.1.5
     opusscript: ^0.0.8
+    play-dl: ^1.9.7
     prettier: ^2.8.4
     tsc-watch: ^6.0.0
-    tsup: ^6.6.3
+    tsup: ^7.2.0
     tsx: ^3.12.7
     typescript: 4.9.5
   languageName: unknown
@@ -9490,6 +9525,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"play-dl@npm:^1.9.7":
+  version: 1.9.7
+  resolution: "play-dl@npm:1.9.7"
+  dependencies:
+    play-audio: ^0.5.2
+  checksum: d626de7fa9231223c1f0480f01eabeb4f50e85d4412501da31049aaf5ebb532032f525b6111f088221cfd29ba8cf5c5c6e85527275c06d7841263c2a306838ee
+  languageName: node
+  linkType: hard
+
 "postcss-import@npm:^15.1.0":
   version: 15.1.0
   resolution: "postcss-import@npm:15.1.0"
@@ -9511,24 +9555,6 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.21
   checksum: 5c1e83efeabeb5a42676193f4357aa9c88f4dc1b3c4a0332c132fe88932b33ea58848186db117cf473049fc233a980356f67db490bd0a7832ccba9d0b3fd3491
-  languageName: node
-  linkType: hard
-
-"postcss-load-config@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "postcss-load-config@npm:3.1.4"
-  dependencies:
-    lilconfig: ^2.0.5
-    yaml: ^1.10.2
-  peerDependencies:
-    postcss: ">=8.0.9"
-    ts-node: ">=9.0.0"
-  peerDependenciesMeta:
-    postcss:
-      optional: true
-    ts-node:
-      optional: true
-  checksum: 1c589504c2d90b1568aecae8238ab993c17dba2c44f848a8f13619ba556d26a1c09644d5e6361b5784e721e94af37b604992f9f3dc0483e687a0cc1cc5029a34
   languageName: node
   linkType: hard
 
@@ -11352,42 +11378,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsup@npm:^6.6.3":
-  version: 6.7.0
-  resolution: "tsup@npm:6.7.0"
-  dependencies:
-    bundle-require: ^4.0.0
-    cac: ^6.7.12
-    chokidar: ^3.5.1
-    debug: ^4.3.1
-    esbuild: ^0.17.6
-    execa: ^5.0.0
-    globby: ^11.0.3
-    joycon: ^3.0.1
-    postcss-load-config: ^3.0.1
-    resolve-from: ^5.0.0
-    rollup: ^3.2.5
-    source-map: 0.8.0-beta.0
-    sucrase: ^3.20.3
-    tree-kill: ^1.2.2
-  peerDependencies:
-    "@swc/core": ^1
-    postcss: ^8.4.12
-    typescript: ">=4.1.0"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    postcss:
-      optional: true
-    typescript:
-      optional: true
-  bin:
-    tsup: dist/cli-default.js
-    tsup-node: dist/cli-node.js
-  checksum: 91ff179f0b9828a6880b6decaa8603fd7af0311f46a38d3a93647a2497298750d676810aeff533a335443a01a7b340dbba7c76523bcd7a87d7b05b7677742901
-  languageName: node
-  linkType: hard
-
 "tsup@npm:^7.2.0":
   version: 7.2.0
   resolution: "tsup@npm:7.2.0"
@@ -11698,6 +11688,15 @@ __metadata:
   dependencies:
     busboy: ^1.6.0
   checksum: 0795b69e0f7e1b2b162bce0d1670e6b44c968960e519f5b450df5196fd9c5102e0838ed854e68e61588f3c2436a3dc3d4390f9bf4a24b04eeb03926fe0eaa599
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.25.2":
+  version: 5.26.3
+  resolution: "undici@npm:5.26.3"
+  dependencies:
+    "@fastify/busboy": ^2.0.0
+  checksum: aaa9aadb712cf80e1a9cea2377e4842670105e00abbc184a21770ea5a8b77e4e2eadc200eac62442e74a1cd3b16a840c6f73b112b9e886bd3c1a125eb22e4f21
   languageName: node
   linkType: hard
 
@@ -12143,6 +12142,7 @@ __metadata:
     remark-gfm: ^3.0.1
     semver: ^7.5.3
     tailwindcss: 3.3.2
+    tsup: ^7.2.0
     typescript: 5.1.3
   languageName: unknown
   linkType: soft
@@ -12293,13 +12293,6 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^1.10.2":
-  version: 1.10.2
-  resolution: "yaml@npm:1.10.2"
-  checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

This PR implements demuxer for `webm/opus` and `ogg/opus` streams. When such streams are available and condition does not require the use of ffmpeg, discord-player will skip ffmpeg entirely. This update does not include breaking changes. Developers currently have to pass `skipFFmpeg: true` in main player options for this to work. We may enable this by default after performing enough tests _(in production)_.

You can still use filters such as `volume controller`, `equalizer` or `biquad` while using `skipFFmpeg` without any issues. You can also use ffmpeg filters but discord-player will switch back to ffmpeg when you use ffmpeg filters or seek().

`skipFFmpeg` may not work all the time, but you should not notice any differences as a user. Currently, this only works with `YoutubeExtractor` (while using `youtube-ext`, `ytdl-core` and `@distube/ytdl-core` - `play-dl` users can try and give feedbacks if needed, `yt-stream` is not implemented yet).

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.