### PR TITLE
feat: add dynamic shuffle mode

### DIFF
--- a/apps/music-bot/src/commands/shuffle.ts
+++ b/apps/music-bot/src/commands/shuffle.ts
@@ -30,7 +30,8 @@ export class ShuffleCommand extends Command {
 				ephemeral: true
 			});
 
-		queue.tracks.shuffle();
-		return interaction.reply({ content: `${this.container.client.dev.success} | I have **shuffled** the queue` });
+		// queue.tracks.shuffle();
+		const status = queue.toggleShuffle();
+		return interaction.reply({ content: `${this.container.client.dev.success} | I have **${status ? 'shuffled' : 'unshuffled'}** the queue` });
 	}
 }

--- a/packages/discord-player/src/utils/Util.ts
+++ b/packages/discord-player/src/utils/Util.ts
@@ -4,6 +4,7 @@ import { setTimeout } from 'timers/promises';
 import { GuildQueue } from '../manager';
 import { Playlist, Track } from '../fabric';
 import { Exceptions } from '../errors';
+import { randomInt } from 'crypto';
 
 class Util {
     /**
@@ -135,7 +136,20 @@ class Util {
     }
 
     static randomChoice<T>(src: T[]): T {
-        return src[Math.floor(Math.random() * src.length)];
+        return src[randomInt(src.length)];
+    }
+
+    static arrayCloneShuffle<T>(src: T[]): T[] {
+        const arr = src.slice();
+
+        let m = arr.length;
+
+        while (m) {
+            const i = Math.floor(Math.random() * m--);
+            [arr[m], arr[i]] = [arr[i], arr[m]];
+        }
+
+        return arr;
     }
 }
 


### PR DESCRIPTION
## Changes

This mode does not mutate the queue and only shuffles before selecting next track. It can be enabled/disabled on-the-fly.

```js
// enables/disables dynamic shuffling mode
queue.toggleShuffle();

// enable
queue.enableShuffle();

// disable
queue.disableShuffle();

// enable traditional shuffle (this is a one-time process)
queue.enableShuffle(false);
queue.tracks.shuffle();
```

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.