### PR TITLE
feat: add bindHook function

### DIFF
--- a/packages/discord-player/src/hooks/common.ts
+++ b/packages/discord-player/src/hooks/common.ts
@@ -1,8 +1,18 @@
+import type { Player } from '../Player';
 import { GuildQueue, NodeResolvable } from '../manager';
 import { instances } from '../utils/__internal__';
 
+const preferredInstanceKey = '__discord_player_hook_instance_cache__';
+
 export const getPlayer = () => {
-    return instances.first() || null;
+    return instances.get(preferredInstanceKey) || instances.first() || null;
+};
+
+/**
+ * Bind a player instance to the hook system, defaults to the first instance.
+ */
+export const bindHook = (player: Player) => {
+    instances.set(preferredInstanceKey, player);
 };
 
 export const getQueue = <T = unknown>(node: NodeResolvable) => {

--- a/packages/discord-player/src/types/types.ts
+++ b/packages/discord-player/src/types/types.ts
@@ -1,9 +1,9 @@
-import { User, UserResolvable, VoiceState } from 'discord.js';
-import { GuildQueue } from '../manager';
-import { Track } from '../fabric/Track';
-import { Playlist } from '../fabric/Playlist';
-import { downloadOptions } from 'ytdl-core';
-import { QueryCacheProvider } from '../utils/QueryCache';
+import type { User, UserResolvable, VoiceState } from 'discord.js';
+import type { GuildQueue } from '../manager';
+import type { Track } from '../fabric/Track';
+import type { Playlist } from '../fabric/Playlist';
+import type { downloadOptions } from 'ytdl-core';
+import type { QueryCacheProvider } from '../utils/QueryCache';
 import type { IPRotationConfig } from '../utils/IPRotator';
 
 // @ts-ignore


### PR DESCRIPTION
## Changes

Currently the hooks exported by discord-player operate on the first instance of `Player`. This PR adds a new function called `bindHook` which allows users to bind hooks to other instance of player.

```js
import { bindHook, useMainPlayer, Player } from 'discord-player'

// create player instance
const player = new Player(client, {...});

// bind hooks to 'player'
bindHook(player);

useMainPlayer() // this equals to 'player' above
```

> This by default uses first instance for compatibility reasons.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.