### PR TITLE
feat(ExtractorExecutionContext): allow passing options via loadDefault

### DIFF
--- a/apps/music-bot/src/listeners/ready.ts
+++ b/apps/music-bot/src/listeners/ready.ts
@@ -14,8 +14,9 @@ export class UserEvent extends Listener {
 
 		const player = useMainPlayer();
 		if (player) {
-			await player.extractors.loadDefault(/* (ext) => ext !== 'YouTubeExtractor' */);
-			console.log(player.scanDeps());
+			// await player.extractors.loadDefault(/* (ext) => ext !== 'YouTubeExtractor' */);
+			// console.log(player.scanDeps());
+			await player.extractors.loadDefault((ext) => ext === 'YouTubeExtractor' || ext === 'SpotifyExtractor' || ext === 'AttachmentExtractor');
 		}
 	}
 }

--- a/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
+++ b/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
@@ -18,7 +18,7 @@ const knownExtractorKeys = [
 const knownExtractorLib = '@discord-player/extractor';
 
 export type ExtractorLoaderOptionDict = {
-    [K in (typeof knownExtractorKeys)[number]]?: ConstructorParameters<typeof import('@discord-player/extractor')[K]>['1'];
+    [K in (typeof knownExtractorKeys)[number]]?: ConstructorParameters<typeof import('@discord-player/extractor')[K]>[1];
 };
 
 export interface ExtractorExecutionEvents {

--- a/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
+++ b/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
@@ -17,6 +17,10 @@ const knownExtractorKeys = [
 ] as const;
 const knownExtractorLib = '@discord-player/extractor';
 
+export type ExtractorLoaderOptionDict = {
+    [K in (typeof knownExtractorKeys)[number]]?: ConstructorParameters<typeof import('@discord-player/extractor')[K]>['1'];
+};
+
 export interface ExtractorExecutionEvents {
     /**
      * Emitted when a extractor is registered
@@ -59,13 +63,13 @@ export class ExtractorExecutionContext extends PlayerEventsEmitter<ExtractorExec
     /**
      * Load default extractors from `@discord-player/extractor`
      */
-    public async loadDefault(filter?: (ext: (typeof knownExtractorKeys)[number]) => boolean) {
+    public async loadDefault(filter?: (ext: (typeof knownExtractorKeys)[number]) => boolean | null, options?: ExtractorLoaderOptionDict) {
         const mod = await Util.import(knownExtractorLib);
         if (mod.error) return { success: false, error: mod.error as Error };
 
         (filter ? knownExtractorKeys.filter(filter) : knownExtractorKeys).forEach((key) => {
             if (!mod.module[key]) return;
-            this.register(<typeof BaseExtractor>mod.module[key], {});
+            this.register(<typeof BaseExtractor>mod.module[key], options?.[key] || {});
         });
 
         return { success: true, error: null };

--- a/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
+++ b/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
@@ -18,6 +18,7 @@ const knownExtractorKeys = [
 const knownExtractorLib = '@discord-player/extractor';
 
 export type ExtractorLoaderOptionDict = {
+    // @ts-ignore types
     [K in (typeof knownExtractorKeys)[number]]?: ConstructorParameters<typeof import('@discord-player/extractor')[K]>[1];
 };
 

--- a/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
+++ b/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
@@ -70,6 +70,7 @@ export class ExtractorExecutionContext extends PlayerEventsEmitter<ExtractorExec
 
         (filter ? knownExtractorKeys.filter(filter) : knownExtractorKeys).forEach((key) => {
             if (!mod.module[key]) return;
+            // @ts-ignore types
             this.register(<typeof BaseExtractor>mod.module[key], options?.[key] || {});
         });
 

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -53,7 +53,7 @@
     "reverbnation-scraper": "^2.0.0",
     "soundcloud.ts": "^0.5.2",
     "spotify-url-info": "^3.2.6",
-    "youtube-sr": "^4.3.8"
+    "youtube-sr": "^4.3.9"
   },
   "typedoc": {
     "entryPoint": "./src/index.ts",

--- a/packages/extractor/src/extractors/common/BridgeProvider.ts
+++ b/packages/extractor/src/extractors/common/BridgeProvider.ts
@@ -84,6 +84,9 @@ export class BridgeProvider {
         const oldQc = ext.createBridgeQuery;
         if (isSoundcloud) ext.createBridgeQuery = (track) => `${track.author} ${track.title}`;
         const res = await bridgefn(ext, track);
+
+        ext.debug(`Extracted bridge metadata using ${isSoundcloud ? 'soundcloud' : 'youtube'} extractor: ${JSON.stringify(res)}`);
+
         ext.createBridgeQuery = oldQc;
 
         return { source: isSoundcloud ? 'soundcloud' : 'youtube', data: res } as BridgedMetadata;

--- a/yarn.lock
+++ b/yarn.lock
@@ -129,7 +129,7 @@ __metadata:
     spotify-url-info: ^3.2.6
     tsup: ^7.2.0
     youtube-ext: ^1.1.14
-    youtube-sr: ^4.3.8
+    youtube-sr: ^4.3.9
     yt-stream: ^1.4.8
     ytdl-core: ^4.11.4
   languageName: unknown
@@ -12335,10 +12335,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"youtube-sr@npm:^4.3.8":
-  version: 4.3.8
-  resolution: "youtube-sr@npm:4.3.8"
-  checksum: 4cdf9d74a426578a1918804e00e6ba87bfea20aa9dec0e6ca7c7892d1473104abde2ee8dc997ee9d84ef1620ca50bafb69fe2b81abf5702bb57143527fcf703b
+"youtube-sr@npm:^4.3.9":
+  version: 4.3.9
+  resolution: "youtube-sr@npm:4.3.9"
+  checksum: f4d5f0d4d05bcc752546e6d8145742917509c9414b5a09371202cb5fc10c75132a004f279a6d0127072ea4485835f90fc9b0ff2cf0f04004d0d74aeb7360dfc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

This PR adds `options` parameter to `loadDefault` method of `ExtractorExecutionContext` which allows devs to pass extractor options in this format:

```js
await player.extractors.loadDefault(null, {
  ExtractorName: {...}
});
```

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.