### PR TITLE
perf: remove unnecessary bridgeProvider check

### DIFF
--- a/packages/extractor/src/extractors/AppleMusicExtractor.ts
+++ b/packages/extractor/src/extractors/AppleMusicExtractor.ts
@@ -133,7 +133,7 @@ export class AppleMusicExtractor extends BridgedExtractor<AppleMusicExtractorIni
                             requestMetadata: async () => {
                                 return {
                                     source: info,
-                                    bridge: this.options.bridgeProvider ? (await this.options.bridgeProvider.resolve(this, track)).data : await pullYTMetadata(this, track)
+                                    bridge: (await this.options.bridgeProvider.resolve(this, track)).data
                                 };
                             }
                         });

--- a/packages/extractor/src/extractors/SpotifyExtractor.ts
+++ b/packages/extractor/src/extractors/SpotifyExtractor.ts
@@ -85,7 +85,7 @@ export class SpotifyExtractor extends BridgedExtractor<SpotifyExtractorInit> {
                             requestMetadata: async () => {
                                 return {
                                     source: spotifyData,
-                                    bridge: this.options.bridgeProvider ? (await this.options.bridgeProvider.resolve(this, track)).data : await pullYTMetadata(this, track)
+                                    bridge: (await this.options.bridgeProvider.resolve(this, track)).data
                                 };
                             }
                         });


### PR DESCRIPTION
## Changes

Remove unnecessary ternary check for bridgeProvider in AppleMusicExtractor and SpotifyExtractor.

This check is not necessary because the baseExtractor already returns default bridgeProvider in case user hasn't provided any.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.