### PR TITLE
feat(BaseExtractor): add protocols support

### DIFF
--- a/apps/music-bot/src/listeners/ready.ts
+++ b/apps/music-bot/src/listeners/ready.ts
@@ -16,7 +16,8 @@ export class UserEvent extends Listener {
 		if (player) {
 			// await player.extractors.loadDefault(/* (ext) => ext !== 'YouTubeExtractor' */);
 			// console.log(player.scanDeps());
-			await player.extractors.loadDefault((ext) => ext === 'YouTubeExtractor' || ext === 'SpotifyExtractor' || ext === 'AttachmentExtractor');
+			// await player.extractors.loadDefault((ext) => ext === 'YouTubeExtractor' || ext === 'SpotifyExtractor' || ext === 'AttachmentExtractor');
+			await player.extractors.loadDefault(/* (ext) => ext !== 'YouTubeExtractor' */);
 		}
 	}
 }

--- a/packages/discord-player/src/extractors/BaseExtractor.ts
+++ b/packages/discord-player/src/extractors/BaseExtractor.ts
@@ -28,6 +28,11 @@ export class BaseExtractor<T extends object = object> {
     public priority = 1;
 
     /**
+     * A list of query protocols that this extractor supports.
+     */
+    public protocols: string[] = [];
+
+    /**
      * Handle bridge query creation
      * @param track The track to build query for
      */
@@ -171,4 +176,5 @@ export interface ExtractorSearchContext {
     type?: SearchQueryType | null;
     requestedBy?: User | null;
     requestOptions?: RequestOptions;
+    protocol?: string | null;
 }

--- a/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
+++ b/packages/discord-player/src/extractors/ExtractorExecutionContext.ts
@@ -56,7 +56,11 @@ export interface ExtractorExecutionEvents {
 }
 
 export class ExtractorExecutionContext extends PlayerEventsEmitter<ExtractorExecutionEvents> {
+    /**
+     * The extractors store
+     */
     public store = new Collection<string, BaseExtractor>();
+
     public constructor(public player: Player) {
         super(['error']);
     }
@@ -216,6 +220,34 @@ export class ExtractorExecutionContext extends PlayerEventsEmitter<ExtractorExec
                 result: false
             } as ExtractorExecutionResult<false>;
     }
+
+    /**
+     * Check if extractor is disabled
+     */
+    public isDisabled(identifier: string) {
+        return this.player.options.blockExtractors?.includes(identifier) ?? false;
+    }
+
+    /**
+     * Check if extractor is enabled
+     */
+    public isEnabled(identifier: string) {
+        return !this.isDisabled(identifier);
+    }
+
+    /**
+     * Resolve extractor identifier
+     */
+    public resolveId(resolvable: ExtractorResolvable) {
+        return typeof resolvable === 'string' ? resolvable : resolvable.identifier;
+    }
+
+    /**
+     * Resolve extractor
+     */
+    public resolve(resolvable: ExtractorResolvable) {
+        return typeof resolvable === 'string' ? this.get(resolvable) : resolvable;
+    }
 }
 
 export interface ExtractorExecutionResult<T = unknown> {
@@ -225,3 +257,5 @@ export interface ExtractorExecutionResult<T = unknown> {
 }
 
 export type ExtractorExecutionFN<T = unknown> = (extractor: BaseExtractor) => Promise<T | boolean>;
+
+export type ExtractorResolvable = string | BaseExtractor;

--- a/packages/extractor/src/extractors/AppleMusicExtractor.ts
+++ b/packages/extractor/src/extractors/AppleMusicExtractor.ts
@@ -15,6 +15,7 @@ export class AppleMusicExtractor extends BridgedExtractor<AppleMusicExtractorIni
     private _stream!: StreamFN;
 
     public async activate(): Promise<void> {
+        this.protocols = ['amsearch', 'applemusic'];
         const fn = this.options.createStream;
 
         if (typeof fn === 'function') {
@@ -22,6 +23,10 @@ export class AppleMusicExtractor extends BridgedExtractor<AppleMusicExtractorIni
                 return fn(this, q);
             };
         }
+    }
+
+    public async deactivate() {
+        this.protocols = [];
     }
 
     public async validate(query: string, type?: SearchQueryType | null | undefined): Promise<boolean> {
@@ -51,6 +56,8 @@ export class AppleMusicExtractor extends BridgedExtractor<AppleMusicExtractorIni
     }
 
     public async handle(query: string, context: ExtractorSearchContext): Promise<ExtractorInfo> {
+        if (context.protocol === 'amsearch') context.type = QueryType.APPLE_MUSIC_SEARCH;
+
         switch (context.type) {
             case QueryType.AUTO:
             case QueryType.AUTO_SEARCH:

--- a/packages/extractor/src/extractors/SoundCloudExtractor.ts
+++ b/packages/extractor/src/extractors/SoundCloudExtractor.ts
@@ -30,10 +30,12 @@ export class SoundCloudExtractor extends BaseExtractor<SoundCloudExtractorInit> 
     });
 
     public async activate(): Promise<void> {
+        this.protocols = ['scsearch', 'soundcloud'];
         SoundCloudExtractor.instance = this;
     }
 
     public async deactivate(): Promise<void> {
+        this.protocols = [];
         SoundCloudExtractor.instance = null;
     }
 
@@ -88,6 +90,7 @@ export class SoundCloudExtractor extends BaseExtractor<SoundCloudExtractorInit> 
     }
 
     public async handle(query: string, context: ExtractorSearchContext): Promise<ExtractorInfo> {
+        if (context.protocol === 'scsearch') context.type = QueryType.SOUNDCLOUD_SEARCH;
         switch (context.type) {
             case QueryType.SOUNDCLOUD_TRACK: {
                 const trackInfo = await this.internal.tracks.getV2(query).catch(Util.noop);

--- a/packages/extractor/src/extractors/SpotifyExtractor.ts
+++ b/packages/extractor/src/extractors/SpotifyExtractor.ts
@@ -26,6 +26,7 @@ export class SpotifyExtractor extends BridgedExtractor<SpotifyExtractorInit> {
     public internal = new SpotifyAPI(this._credentials);
 
     public async activate(): Promise<void> {
+        this.protocols = ['spsearch', 'spotify'];
         this._lib = spotify(fetch);
         if (this.internal.isTokenExpired()) await this.internal.requestToken();
 
@@ -35,6 +36,12 @@ export class SpotifyExtractor extends BridgedExtractor<SpotifyExtractorInit> {
                 return fn(this, q);
             };
         }
+    }
+
+    public async deactivate() {
+        this._stream = undefined as unknown as StreamFN;
+        this._lib = undefined as unknown as Spotify;
+        this.protocols = [];
     }
 
     public async validate(query: string, type?: SearchQueryType | null | undefined): Promise<boolean> {
@@ -57,6 +64,7 @@ export class SpotifyExtractor extends BridgedExtractor<SpotifyExtractorInit> {
     }
 
     public async handle(query: string, context: ExtractorSearchContext): Promise<ExtractorInfo> {
+        if (context.protocol === 'spsearch') context.type = QueryType.SPOTIFY_SEARCH;
         switch (context.type) {
             case QueryType.AUTO:
             case QueryType.AUTO_SEARCH:

--- a/packages/extractor/src/extractors/YoutubeExtractor.ts
+++ b/packages/extractor/src/extractors/YoutubeExtractor.ts
@@ -33,6 +33,7 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
     public static instance: YoutubeExtractor | null;
 
     public async activate() {
+        this.protocols = ['ytsearch', 'youtube'];
         const fn = this.options.createStream;
 
         if (typeof fn === 'function') {
@@ -49,6 +50,7 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
     }
 
     public async deactivate(): Promise<void> {
+        this.protocols = [];
         YoutubeExtractor.instance = null;
     }
 
@@ -66,6 +68,7 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
     }
 
     public async handle(query: string, context: ExtractorSearchContext): Promise<ExtractorInfo> {
+        if (context.protocol === 'ytsearch') context.type = QueryType.YOUTUBE_SEARCH;
         query = query.includes('youtube.com') ? query.replace(/(m(usic)?|gaming)\./, '') : query;
         if (!query.includes('list=RD') && YoutubeExtractor.validateURL(query)) context.type = QueryType.YOUTUBE_VIDEO;
 


### PR DESCRIPTION
## Changes

This PR adds support for `protocol` list, which is declared by the registered extractors. The behavior is similar to lavalink. For example, if you need to make youtube search, you can use `ytsearch:QUERY_VALUE`, which will be routed to the extractor that supports this protocol. If no extractor is found, discord-player switches back to old behavior.

Default extractors such as:
- YoutubeExtractor (`ytsearch`, `youtube`)
- SoundcloudExtractor (`scsearch`, `soundcloud`)
- SpotifyExtractor (`spsearch`, `spotify`)
- AppleMusicExtractor (`amsearch`, `applemusic`)

support protocols.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.