### PR TITLE
docs: add music-bot to showcase

### DIFF
--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -28,7 +28,7 @@ const PromotedList: IShowcase = {
 
 // you don't need to care about sorting by version, just add your project here
 export const ShowcaseResource: IShowcase = {
-    bots: PromotedList.concat([
+    bots: PromotedList.bots.concat([
         {
             name: 'Mirasaki Music Bot',
             description: 'Complete (45+ commands) music bot with persistent settings, effects, filters, auto-play, DJ-roles, and much more.',
@@ -170,7 +170,7 @@ export const ShowcaseResource: IShowcase = {
             url: 'https://github.com/ToothlessBrush/AstroMonkey'
         }
     ].sort((a, b) => semver.rcompare(a.version, b.version))),
-    extractors: [
+    extractors: PromotedList.extractors.concat([
         {
             name: 'discord-player-deezer',
             description: 'An unofficial extractor for discord-player to add support for deezer source.',
@@ -181,5 +181,5 @@ export const ShowcaseResource: IShowcase = {
             description: 'Unofficial discord-player extractor for Yandex Music.',
             url: 'https://npm.im/discord-player-yandexmusic'
         }
-    ]
+    ])
 };

--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -14,9 +14,21 @@ interface IShowcase {
     }[];
 }
 
+const PromotedList: IShowcase = {
+    bots: [
+        {
+            name: 'Music Bot',
+            description: 'A complete music bot example covering topics like custom playlists, persistent config, custom extractor, redis cache, web interface and more.',
+            version: 'latest',
+            url: 'https://github.com/twlite/music-bot'
+        }
+    ],
+    extractors: []
+};
+
 // you don't need to care about sorting by version, just add your project here
 export const ShowcaseResource: IShowcase = {
-    bots: [
+    bots: PromotedList.concat([
         {
             name: 'Mirasaki Music Bot',
             description: 'Complete (45+ commands) music bot with persistent settings, effects, filters, auto-play, DJ-roles, and much more.',
@@ -157,7 +169,7 @@ export const ShowcaseResource: IShowcase = {
             version: 'v6.6.3',
             url: 'https://github.com/ToothlessBrush/AstroMonkey'
         }
-    ].sort((a, b) => semver.rcompare(a.version, b.version)),
+    ].sort((a, b) => semver.rcompare(a.version, b.version))),
     extractors: [
         {
             name: 'discord-player-deezer',

--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -19,8 +19,14 @@ const PromotedList: IShowcase = {
         {
             name: 'Music Bot',
             description: 'A complete music bot example covering topics like custom playlists, persistent config, custom extractor, redis cache, web interface and more.',
-            version: 'latest',
+            version: '(Promoted)',
             url: 'https://github.com/twlite/music-bot'
+        },
+        {
+            name: 'Cadence',
+            description: 'A free music and audio bot for Discord. No locked functionality, free forever. Open source!',
+            version: 'v6.6.4',
+            url: 'https://github.com/mariusbegby/cadence-discord-bot'
         }
     ],
     extractors: []
@@ -149,12 +155,6 @@ export const ShowcaseResource: IShowcase = {
             description: 'We are using discord-player to manager all of our music commands.',
             version: 'v4.1.0',
             url: 'https://github.com/Androz2091/AtlantaBot'
-        },
-        {
-            name: 'Cadence',
-            description: 'A free music and audio bot for Discord. No locked functionality, free forever. Open source!',
-            version: 'v6.6.4',
-            url: 'https://github.com/mariusbegby/cadence-discord-bot'
         },
         {
             name: 'Elite Music',


### PR DESCRIPTION
## Changes

I built this bot covering all the major topics of this library such as:

- custom playlists (saving/retrieving tracks from database)
- creating custom extractors to handle custom playlists
- using redis as query cache provider
- persistent player config (saving volume, filters, etc in database)
- web interface to manage the queue via gui *WIP*
- and more...

## Status

- [x] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.