### PR TITLE
docs: Update community bot Music-Disc version

### DIFF
--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -64,8 +64,8 @@ export const ShowcaseResource: IShowcase = {
             {
                 name: 'Music Disc',
                 description: "I am using discord-player to play music on Discord with friends. It's easy to set up and run yourself.",
-                version: 'v6.3.0',
-                url: 'https://github.com/hmes98318/Music-Disc'
+                version: 'v6.6.6',
+                url: 'https://github.com/hmes98318/Music-Disc-discord-player'
             },
             {
                 name: 'Botanique',


### PR DESCRIPTION
## Changes
Update community bot [Music-Disc](https://github.com/hmes98318/Music-Disc) module version to **v6.6.6**, and Repository link

## Status

- [ ] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.