### PR TITLE
Fix play-dl cookie setting error

### DIFF
--- a/packages/extractor/src/extractors/common/helper.ts
+++ b/packages/extractor/src/extractors/common/helper.ts
@@ -240,7 +240,9 @@ export async function loadYtdl(options?: any, force = false) {
 
                 if (typeof options?.requestOptions?.headers?.cookie === 'string') {
                     dl.setToken({
-                        youtube: options.requestOptions.headers.cookie
+                        youtube: {
+                            cookie: options.requestOptions.headers.cookie
+                        }
                     });
                 }
                 const info = await dl.video_info(query);


### PR DESCRIPTION
## Changes
Fixed an error caused when trying to use tokens with the play-dl library that would cause extraction errors for any song.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.