### PR TITLE
feat: add async context api for hooks

### DIFF
--- a/apps/website/src/pages/guide/_guides/hooks/using_hooks.mdx
+++ b/apps/website/src/pages/guide/_guides/hooks/using_hooks.mdx
@@ -4,51 +4,51 @@ Discord-Player has a lot of useful hooks, that can be used anywhere once the Pla
 
 Here are few examples on how to use them :
 
-# Stream Hooks
-
-Stream hooks are middleware which has the ability to modify the streaming behavior. There are two types of stream hooks in Discord Player:
-
-### onBeforeCreateStream
-
-Discord Player by default uses registered extractors to stream audio. If you need to override what needs to be streamed, you can use this hook.
-
-> Sample Use Case : If you have local files for commonly played songs, then you can use `onBeforeCreateStream` to use the local file rather than fetching it from some online source.
-
-```js
-const { onBeforeCreateStream } = require("discord-player");
-const fs = require('fs');
-const queue = player.nodes.create(..., {
-    ...,
-    async onBeforeCreateStream(track, source, _queue) {
-        if (track.title === 'some title') {
-            return fs.createReadStream('./playThisInstead.mp3');
-        }
-    }
-});
-```
-
-`<GuildQueue>.onBeforeCreateStream` is called before actually downloading the stream. It is a different concept from extractors, where you are **just** downloading
-streams. `source` here will be a track source. Streams from `onBeforeCreateStream` are then piped to `FFmpeg` and sent to `onAfterCreateStream` hook.
-
-### onAfterCreateStream
-
-This hook can be used to post-process pcm stream. This is the final step before creating audio resource. Example:
-
-```js
-const { onAfterCreateStream } = require("discord-player");
-const queue = player.nodes.create(..., {
-    ...,
-    async onAfterCreateStream(pcmStream, queue) {
-        const encoder = new OpusEncoder();
-        return {
-            stream: encoder.encode(pcmStream),
-            type: StreamType.Opus
-        };
-    }
-});
-```
-
 # General Hooks
+
+These hooks provide access to the player instance, queue, history, metadata, timeline, player node, etc. There are two ways to use these hooks:
+
+1. **Using the hooks with `NodeResolvable` argument**: This mode allows you to use hooks anywhere by providing node resolvable as an argument (like guild object or guild id, etc.). An example of this is shown below:
+
+```js
+const { useQueue } = require('discord-player');
+
+// your command
+export async function execute(interaction) {
+    // here we are passing the guild id as an argument
+    const queue = useQueue(interaction.guild.id);
+}
+```
+
+2. **Using the hooks without arguments**: This mode allows you to use hooks only inside the `HooksContextProvider`. This is useful when you want to use hooks in the command handler or similar places without having to pass the node resolvable every time. An example of this is shown below:
+
+First of all, your command handler needs to provide context to `HooksContextProvider`:
+
+```js
+const { withContext } = require('discord-player');
+
+client.on('interactionCreate', async (interaction) => {
+    if (!interaction.isCommand()) return;
+
+    // assuming the following code is your target command to be executed
+    const command = getCommandSomehow(); // shape is roughly { execute: Function }
+
+    const context = { guild: interaction.guild };
+
+    // provide context and execute the command
+    await withContext(context, () => command.execute(interaction));
+});
+```
+
+```js
+const { useQueue } = require('discord-player');
+
+// your command
+export async function execute(interaction) {
+    // here we are not passing any arguments, discord-player will automatically resolve correct queue based on the context
+    const queue = useQueue();
+}
+```
 
 ## useMainPlayer (Fetch the player instance)
 
@@ -134,4 +134,48 @@ setVolume(200);
 
 // `setPosition()` seeks the current track. Takes timestamp in ms as input.
 await setPosition(18400);
+```
+
+# Stream Hooks
+
+Stream hooks are middleware which has the ability to modify the streaming behavior. There are two types of stream hooks in Discord Player:
+
+### onBeforeCreateStream
+
+Discord Player by default uses registered extractors to stream audio. If you need to override what needs to be streamed, you can use this hook.
+
+> Sample Use Case : If you have local files for commonly played songs, then you can use `onBeforeCreateStream` to use the local file rather than fetching it from some online source.
+
+```js
+const { onBeforeCreateStream } = require("discord-player");
+const fs = require('fs');
+const queue = player.nodes.create(..., {
+    ...,
+    async onBeforeCreateStream(track, source, _queue) {
+        if (track.title === 'some title') {
+            return fs.createReadStream('./playThisInstead.mp3');
+        }
+    }
+});
+```
+
+`<GuildQueue>.onBeforeCreateStream` is called before actually downloading the stream. It is a different concept from extractors, where you are **just** downloading
+streams. `source` here will be a track source. Streams from `onBeforeCreateStream` are then piped to `FFmpeg` and sent to `onAfterCreateStream` hook.
+
+### onAfterCreateStream
+
+This hook can be used to post-process pcm stream. This is the final step before creating audio resource. Example:
+
+```js
+const { onAfterCreateStream } = require("discord-player");
+const queue = player.nodes.create(..., {
+    ...,
+    async onAfterCreateStream(pcmStream, queue) {
+        const encoder = new OpusEncoder();
+        return {
+            stream: encoder.encode(pcmStream),
+            type: StreamType.Opus
+        };
+    }
+});
 ```

--- a/packages/discord-player/src/hooks/common.ts
+++ b/packages/discord-player/src/hooks/common.ts
@@ -1,4 +1,6 @@
+import { Guild } from 'discord.js';
 import type { Player } from '../Player';
+import { createContext, useContext } from './context/async-context';
 import { GuildQueue, NodeResolvable } from '../manager';
 import { instances } from '../utils/__internal__';
 
@@ -6,6 +8,20 @@ const preferredInstanceKey = '__discord_player_hook_instance_cache__';
 
 export const getPlayer = () => {
     return instances.get(preferredInstanceKey) || instances.first() || null;
+};
+
+export interface HooksCtx {
+    guild: Guild;
+}
+
+export const HooksContextProvider = createContext<HooksCtx>();
+export const withContext = HooksContextProvider.provide.bind(HooksContextProvider);
+
+export const useHooksContext = () => {
+    const ctx = useContext(HooksContextProvider);
+    if (!ctx) throw new Error('useHooksContext must be called inside a HooksContextProvider');
+
+    return ctx;
 };
 
 /**

--- a/packages/discord-player/src/hooks/context/async-context.ts
+++ b/packages/discord-player/src/hooks/context/async-context.ts
@@ -1,0 +1,99 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type unsafe = any;
+
+/**
+ * The receiver function that will be called when the context is provided
+ */
+export type ContextReceiver<R> = () => R;
+
+/**
+ * The props for the context provider
+ */
+export interface ContextProviderProps<T, R> {
+    /**
+     * The value to provide
+     */
+    value: T;
+    /**
+     * The receiver function that will be called when the context is provided
+     */
+    receiver: ContextReceiver<R>;
+}
+
+export class Context<T> {
+    private storage = new AsyncLocalStorage<T>();
+
+    public constructor(private defaultValue?: T) {}
+
+    /**
+     * Exit out of this context
+     */
+    public exit(scope: ContextReceiver<void>) {
+        this.storage.exit(scope);
+    }
+
+    /**
+     * Whether the context is lost
+     */
+    public get isLost() {
+        return this.storage.getStore() === undefined;
+    }
+
+    /**
+     * Get the current value of the context. If the context is lost and no default value is provided, undefined will be returned.
+     */
+    public getValue(): T | undefined {
+        const data = this.storage.getStore();
+
+        if (data === undefined && this.defaultValue !== undefined) return this.defaultValue;
+
+        return data;
+    }
+
+    /**
+     * Run a function within the context of this provider
+     */
+    public provide<R = unsafe>({ receiver, value }: ContextProviderProps<T, R>): R {
+        if (value === undefined) {
+            throw new Error('Context value may not be undefined');
+        }
+
+        return this.storage.run(value, receiver);
+    }
+}
+
+/**
+ * Create a new context. The default value is optional.
+ * @param defaultValue The default value of the context
+ * @example const userContext = createContext();
+ *
+ *  // the value to provide
+ *  const user = {
+ *   id: 1,
+ *   name: 'John Doe'
+ *  };
+ *
+ *  // provide the context value to the receiver
+ *  context.provide({ value: user, receiver: handler });
+ *
+ *  function handler() {
+ *    // get the context value
+ *    const { id, name } = useContext(context);
+ *
+ *    console.log(id, name); // 1, John Doe
+ *  }
+ */
+export function createContext<T = unsafe>(defaultValue?: T): Context<T> {
+    return new Context(defaultValue);
+}
+
+/**
+ * Get the current value of the context. If the context is lost and no default value is provided, undefined will be returned.
+ * @param context The context to get the value from
+ * @example const value = useContext(context);
+ */
+export function useContext<T = unsafe>(context: Context<T>): T | undefined {
+    return context.getValue();
+}

--- a/packages/discord-player/src/hooks/index.ts
+++ b/packages/discord-player/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './context/async-context';
 export * from './useHistory';
 export * from './usePlayer';
 export * from './useQueue';

--- a/packages/discord-player/src/hooks/useHistory.ts
+++ b/packages/discord-player/src/hooks/useHistory.ts
@@ -1,12 +1,16 @@
-import { NodeResolvable } from '../manager';
-import { getQueue } from './common';
+import { GuildQueueHistory, NodeResolvable } from '../manager';
+import { getQueue, useHooksContext } from './common';
 
 /**
  * Fetch guild queue history
  * @param node guild queue node resolvable
  */
-export function useHistory<Meta = unknown>(node: NodeResolvable) {
-    const queue = getQueue<Meta>(node);
+export function useHistory<Meta = unknown>(): GuildQueueHistory<Meta> | null;
+export function useHistory<Meta = unknown>(node: NodeResolvable): GuildQueueHistory<Meta> | null;
+export function useHistory<Meta = unknown>(node?: NodeResolvable): GuildQueueHistory<Meta> | null {
+    const _node = node ?? useHooksContext().guild;
+
+    const queue = getQueue<Meta>(_node);
     if (!queue) return null;
 
     return queue.history;

--- a/packages/discord-player/src/hooks/useMetadata.ts
+++ b/packages/discord-player/src/hooks/useMetadata.ts
@@ -1,15 +1,19 @@
 import { TypeUtil } from '../utils/TypeUtil';
 import { NodeResolvable } from '../manager';
-import { getQueue } from './common';
+import { getQueue, useHooksContext } from './common';
 
-type SetterFN<T, P> = (previous: P) => T;
+export type SetterFN<T, P> = (previous: P) => T;
+export type MetadataDispatch<T> = readonly [() => T, (metadata: T | SetterFN<T, T>) => void];
 
 /**
  * Fetch or manipulate guild queue metadata
  * @param node Guild queue node resolvable
  */
-export function useMetadata<T = unknown>(node: NodeResolvable) {
-    const queue = getQueue<T>(node);
+export function useMetadata<T = unknown>(): MetadataDispatch<T>;
+export function useMetadata<T = unknown>(node: NodeResolvable): MetadataDispatch<T>;
+export function useMetadata<T = unknown>(node?: NodeResolvable): MetadataDispatch<T> {
+    const _node = node ?? useHooksContext().guild;
+    const queue = getQueue<T>(_node);
     const setter = (metadata: T | SetterFN<T, T>) => {
         if (queue) {
             if (TypeUtil.isFunction(metadata)) return queue.setMetadata(metadata(queue.metadata));

--- a/packages/discord-player/src/hooks/usePlayer.ts
+++ b/packages/discord-player/src/hooks/usePlayer.ts
@@ -1,12 +1,15 @@
-import { NodeResolvable } from '../manager';
-import { getQueue } from './common';
+import { GuildQueuePlayerNode, NodeResolvable } from '../manager';
+import { getQueue, useHooksContext } from './common';
 
 /**
  * Fetch guild queue player node
  * @param node Guild queue node resolvable
  */
-export function usePlayer<Meta = unknown>(node: NodeResolvable) {
-    const queue = getQueue<Meta>(node);
+export function usePlayer<Meta = unknown>(): GuildQueuePlayerNode<Meta> | null;
+export function usePlayer<Meta = unknown>(node: NodeResolvable): GuildQueuePlayerNode<Meta> | null;
+export function usePlayer<Meta = unknown>(node?: NodeResolvable): GuildQueuePlayerNode<Meta> | null {
+    const _node = node ?? useHooksContext().guild;
+    const queue = getQueue<Meta>(_node);
     if (!queue) return null;
 
     return queue.node;

--- a/packages/discord-player/src/hooks/useQueue.ts
+++ b/packages/discord-player/src/hooks/useQueue.ts
@@ -1,12 +1,15 @@
-import { NodeResolvable } from '../manager';
-import { getQueue } from './common';
+import { GuildQueue, NodeResolvable } from '../manager';
+import { getQueue, useHooksContext } from './common';
 
 /**
  * Fetch guild queue
  * @param node Guild queue node resolvable
  */
-export function useQueue<Meta = unknown>(node: NodeResolvable) {
-    const queue = getQueue<Meta>(node);
+export function useQueue<Meta = unknown>(): GuildQueue<Meta> | null;
+export function useQueue<Meta = unknown>(node: NodeResolvable): GuildQueue<Meta> | null;
+export function useQueue<Meta = unknown>(node?: NodeResolvable): GuildQueue<Meta> | null {
+    const _node = node ?? useHooksContext().guild;
+    const queue = getQueue<Meta>(_node);
     if (!queue) return null;
 
     return queue;

--- a/packages/discord-player/src/hooks/useTimeline.ts
+++ b/packages/discord-player/src/hooks/useTimeline.ts
@@ -1,5 +1,5 @@
 import { NodeResolvable } from '../manager';
-import { getQueue } from './common';
+import { getQueue, useHooksContext } from './common';
 
 export interface TimelineDispatcherOptions {
     ignoreFilters: boolean;
@@ -10,8 +10,9 @@ export interface TimelineDispatcherOptions {
  * @param node Guild queue node resolvable
  * @param options Options for timeline dispatcher
  */
-export function useTimeline(node: NodeResolvable, options?: Partial<TimelineDispatcherOptions>) {
-    const queue = getQueue(node);
+export function useTimeline(node?: NodeResolvable, options?: Partial<TimelineDispatcherOptions>) {
+    const _node = node ?? useHooksContext().guild;
+    const queue = getQueue(_node);
     if (!queue) return null;
 
     return Object.preventExtensions({

--- a/packages/discord-player/src/hooks/useVolume.ts
+++ b/packages/discord-player/src/hooks/useVolume.ts
@@ -1,15 +1,19 @@
 import { TypeUtil } from '../utils/TypeUtil';
 import { NodeResolvable } from '../manager';
-import { getQueue } from './common';
+import { getQueue, useHooksContext } from './common';
 
 type SetterFN = (previous: number) => number;
+type VolumeDispatch = readonly [() => number, (volume: number | SetterFN) => boolean | undefined];
 
 /**
  * Fetch or manipulate player volume
  * @param node Guild queue node resolvable
  */
-export function useVolume(node: NodeResolvable) {
-    const queue = getQueue(node);
+export function useVolume(): VolumeDispatch;
+export function useVolume(node: NodeResolvable): VolumeDispatch;
+export function useVolume(node?: NodeResolvable): VolumeDispatch {
+    const _node = node ?? useHooksContext().guild;
+    const queue = getQueue(_node);
     const setter = (volume: number | SetterFN) => {
         if (queue) {
             if (TypeUtil.isFunction(volume)) return queue.node.setVolume(volume(queue.node.volume));

--- a/packages/discord-player/src/utils/Util.ts
+++ b/packages/discord-player/src/utils/Util.ts
@@ -1,10 +1,10 @@
 import { StageChannel, VoiceChannel } from 'discord.js';
 import { TimeData } from '../types/types';
-import { setTimeout } from 'timers/promises';
+import { setTimeout } from 'node:timers/promises';
 import { GuildQueue } from '../manager';
 import { Playlist, Track } from '../fabric';
 import { Exceptions } from '../errors';
-import { randomInt } from 'crypto';
+import { randomInt } from 'node:crypto';
 
 class Util {
     /**


### PR DESCRIPTION
### Alternate api for hooks

Previous methods still work and this mode is opt-in. In order to enable this api, the command handler needs to provide context to `HooksContextProvider` and hooks must be called without any arguments. The benefit of this approach is you don't need to care about passing guild id every time you want to access something inside the command. Hooks will resolve correct data even if the same command is executed multiple times concurrently.

> Note: This only works inside the call stack created by `withContext` function.

```js
const { withContext } = require('discord-player');

client.on('interactionCreate', async (interaction) => {
    if (!interaction.isCommand()) return;

    // assuming the following code is your target command to be executed
    const command = getCommandSomehow(); // shape is roughly { execute: Function }

    const context = { guild: interaction.guild };

    // provide context and execute the command
    await withContext(context, () => command.execute(interaction));
});
```

Then discord-player hooks can be used without providing guild id.

```js
const { useQueue } = require('discord-player');

// your command
export async function execute(interaction) {
    // here we are not passing any arguments, discord-player will automatically resolve correct queue based on the context
    const queue = useQueue();
}
```