### PR TITLE
Now player can search on m.youtube.com (#1891)

### DIFF
--- a/packages/discord-player/src/utils/QueryResolver.ts
+++ b/packages/discord-player/src/utils/QueryResolver.ts
@@ -21,7 +21,7 @@ const youtubeVideoIdRegex = /^[a-zA-Z0-9-_]{11}$/;
 // #endregion scary things above *sigh*
 
 const DomainsMap = {
-    YouTube: ['youtube.com', 'youtu.be', 'music.youtube.com', 'gaming.youtube.com', 'www.youtube.com'],
+    YouTube: ['youtube.com', 'youtu.be', 'music.youtube.com', 'gaming.youtube.com', 'www.youtube.com', 'm.youtube.com'],
     Spotify: ['open.spotify.com', 'embed.spotify.com'],
     Vimeo: ['vimeo.com', 'player.vimeo.com'],
     ReverbNation: ['reverbnation.com'],


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->
This PR will close #1891.
As pointed out on [the comment](https://github.com/Androz2091/discord-player/issues/1891#issuecomment-2012012203), the query resolver rejects `m.youtube.com` domain because it is not in `DomainsMap.YouTube`.
It will be fixed by adding `'m.youtube.com'` to the array.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.