### PR TITLE
Temporary fix to not emit audioTrackRemove event upon jumping to a track

### DIFF
--- a/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
+++ b/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
@@ -302,8 +302,9 @@ export class GuildQueuePlayerNode<Meta = unknown> {
     /**
      * Remove the given track from queue
      * @param track The track to remove
+     * @param emitEvent Whether or not to emit the event @defaultValue true
      */
-    public remove(track: TrackResolvable) {
+    public remove(track: TrackResolvable, emitEvent = true) {
         const foundTrack = this.queue.tracks.find((t, idx) => {
             if (track instanceof Track || typeof track === 'string') {
                 return (typeof track === 'string' ? track : track.id) === t.id;
@@ -315,7 +316,7 @@ export class GuildQueuePlayerNode<Meta = unknown> {
 
         this.queue.tracks.removeOne((t) => t.id === foundTrack.id);
 
-        this.queue.emit(GuildQueueEvent.audioTrackRemove, this.queue, foundTrack);
+        if(emitEvent) this.queue.emit(GuildQueueEvent.audioTrackRemove, this.queue, foundTrack);
 
         return foundTrack;
     }
@@ -325,7 +326,7 @@ export class GuildQueuePlayerNode<Meta = unknown> {
      * @param track The track to jump to without removing other tracks
      */
     public jump(track: TrackResolvable) {
-        const removed = this.remove(track);
+        const removed = this.remove(track, false);
         if (!removed) return false;
         this.queue.tracks.store.unshift(removed);
         return this.skip({


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->

Added a boolean parameter named `emitEvent` which defaults to true for `<GuildQueuePlayerNode>.jump`.

I ran into an issue, where I would like to jump to a track without it emitting the event `audioTrackRemove`, I think that is a bug **If it's not please let me know**. This introduces a temporary fix for it. It can be modified to be extendable. It defaults to true, so the code doesn't break in other areas, so it's semi-optional **not entirely but I don't know how to word it**. It can be also changed from defaulting it to true, it being an optional parameter. It's dependent on how you want it to behave.

## Status

- [✔️] These changes have been tested and formatted properly.
- [❌] This PR includes only documentation changes, no code change.
- [❌] This PR introduces some Breaking changes.