### PR TITLE
Fix Youtube bridge query issue using url instead of creating string

### DIFF
--- a/packages/extractor/src/extractors/YoutubeExtractor.ts
+++ b/packages/extractor/src/extractors/YoutubeExtractor.ts
@@ -268,12 +268,13 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
             return this.stream(track);
         }
 
-        const info = await this.handle(track.url, {
-            requestedBy: track.requestedBy
+        const query = sourceExtractor?.createBridgeQuery(track) ?? `${track.author} - ${track.title}`;
+        const info = await this.handle(query, {
+            requestedBy: track.requestedBy,
+            type: QueryType.YOUTUBE
         });
 
         if (!info.tracks.length) return null;
-
         return this.stream(info.tracks[0]);
     }
 


### PR DESCRIPTION
## Changes

YoutubeExtractor `bridge()` method used `track.url` for searching resulting in no search results (e.g. spotify url provided when using youtube as bridge, then youtube extractor tries searching for spotify track url..).

This PR fixes this bug by creating an actual searchable query string which then gets executed, to finally return a track.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.