### PR TITLE
Fix: Type mismatch in the <Track>.raw property

### DIFF
--- a/packages/discord-player/src/fabric/Track.ts
+++ b/packages/discord-player/src/fabric/Track.ts
@@ -30,14 +30,13 @@ export class Track<T = unknown> {
     public requestedBy: User | null = null;
     public playlist?: Playlist;
     public queryType: SearchQueryType | null | undefined = null;
-    public raw: RawTrackData = {
-        source: 'arbitrary'
-    } as RawTrackData;
+    public raw: any;
     public extractor: BaseExtractor | null = null;
     public readonly id = SnowflakeUtil.generate().toString();
     private __metadata: T | null = null;
     private __reqMetadataFn: () => Promise<T | null>;
     public cleanTitle: string;
+    public live: boolean = false
 
     /**
      * Track constructor
@@ -59,6 +58,7 @@ export class Track<T = unknown> {
         this.__metadata = data.metadata ?? null;
         this.__reqMetadataFn = data.requestMetadata || (() => Promise.resolve<T | null>(null));
         this.cleanTitle = data.cleanTitle ?? Util.cleanTitle(this.title, this.source);
+        this.live = data.live ?? false
     }
 
     /**

--- a/packages/extractor/src/extractors/AttachmentExtractor.ts
+++ b/packages/extractor/src/extractors/AttachmentExtractor.ts
@@ -105,7 +105,6 @@ export class AttachmentExtractor extends BaseExtractor {
 
                 track.extractor = this;
 
-                // @ts-expect-error
                 track.raw.isFile = false;
 
                 return { playlist: null, tracks: [track] };
@@ -180,7 +179,6 @@ export class AttachmentExtractor extends BaseExtractor {
 
                 track.extractor = this;
 
-                // @ts-expect-error
                 track.raw.isFile = true;
 
                 return { playlist: null, tracks: [track] };
@@ -196,7 +194,7 @@ export class AttachmentExtractor extends BaseExtractor {
 
     public async stream(info: Track) {
         const engine = info.raw.engine as string;
-        // @ts-expect-error
+
         const isFile = info.raw.isFile as boolean;
 
         if (!engine) throw new Error('Could not find stream source');

--- a/packages/extractor/src/extractors/YoutubeExtractor.ts
+++ b/packages/extractor/src/extractors/YoutubeExtractor.ts
@@ -119,7 +119,8 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
                         metadata: video,
                         async requestMetadata() {
                             return video;
-                        }
+                        },
+                        live: video.live
                     });
 
                     track.extractor = this;
@@ -153,7 +154,8 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
                     metadata: video,
                     async requestMetadata() {
                         return video;
-                    }
+                    },
+                    live: video.live
                 });
 
                 track.extractor = this;
@@ -193,7 +195,8 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
                 metadata: video,
                 async requestMetadata() {
                     return video;
-                }
+                },
+                live: video.live
             });
 
             track.extractor = this;
@@ -237,7 +240,8 @@ export class YoutubeExtractor extends BaseExtractor<YoutubeExtractorInit> {
                 metadata: video,
                 async requestMetadata() {
                     return video;
-                }
+                },
+                live: video.live
             });
 
             t.extractor = this;


### PR DESCRIPTION
## Changes
Fixes <Track>.raw being typed RawTrackData and export .live property from .raw

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.