### PR TITLE
Add ffmpegPath option

### DIFF
--- a/packages/discord-player/__test__/Player.spec.ts
+++ b/packages/discord-player/__test__/Player.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, test } from 'vitest';
 import { Player, SearchResult } from '../src/index';
 import { Client, IntentsBitField } from 'discord.js';
 
@@ -38,4 +38,14 @@ describe('Player', () => {
 
         expect(response).toBeInstanceOf(SearchResult);
     });
+
+    test("should set process.env.FFMPEG_PATH to given path", () => {
+        // not actual ffmpeg path. just dummy
+        new Player(client, {
+            ffmpegPath: "./packages/ffmpeg",
+            ignoreInstance: true
+        })
+      
+        expect(process.env.FFMPEG_PATH).toBe("./packages/ffmpeg")
+    })
 });

--- a/packages/discord-player/src/Player.ts
+++ b/packages/discord-player/src/Player.ts
@@ -19,6 +19,7 @@ import { Context, createContext } from './hooks';
 import { HooksCtx } from './hooks/common';
 import { LrcLib } from './lrclib/LrcLib';
 import { existsSync } from 'fs';
+import { spawnSync } from 'child_process';
 
 const kSingleton = Symbol('InstanceDiscordPlayerSingleton');
 
@@ -108,6 +109,12 @@ export class Player extends PlayerEventsEmitter<PlayerEvents> {
         if(options.ffmpegPath) {
             if(typeof options.ffmpegPath !== "string") throw new TypeError(`Expected type "string" for options.ffmpegPath. Got ${typeof options.ffmpegPath} instead`)
             if(!existsSync(options.ffmpegPath)) throw new Error(`The pathway provided for options.ffmpegPath does not exists.`)
+
+            try {
+                spawnSync(options.ffmpegPath, ['--help'])
+            } catch (error) {
+                throw new Error(`Cannot find FFmpeg at the given pathway.\n\n${error}`)
+            }
 
             process.env.FFMPEG_PATH = options.ffmpegPath
         }

--- a/packages/discord-player/src/Player.ts
+++ b/packages/discord-player/src/Player.ts
@@ -108,13 +108,6 @@ export class Player extends PlayerEventsEmitter<PlayerEvents> {
 
         if(options.ffmpegPath) {
             if(typeof options.ffmpegPath !== "string") throw new TypeError(`Expected type "string" for options.ffmpegPath. Got ${typeof options.ffmpegPath} instead`)
-            if(!existsSync(options.ffmpegPath)) throw new Error(`The pathway provided for options.ffmpegPath does not exists.`)
-
-            try {
-                spawnSync(options.ffmpegPath, ['--help'])
-            } catch (error) {
-                throw new Error(`Cannot find FFmpeg at the given pathway.\n\n${error}`)
-            }
 
             process.env.FFMPEG_PATH = options.ffmpegPath
         }

--- a/packages/discord-player/src/Player.ts
+++ b/packages/discord-player/src/Player.ts
@@ -18,6 +18,7 @@ import { IPRotator } from './utils/IPRotator';
 import { Context, createContext } from './hooks';
 import { HooksCtx } from './hooks/common';
 import { LrcLib } from './lrclib/LrcLib';
+import { existsSync } from 'fs';
 
 const kSingleton = Symbol('InstanceDiscordPlayerSingleton');
 
@@ -172,6 +173,13 @@ export class Player extends PlayerEventsEmitter<PlayerEvents> {
                 configurable: true,
                 enumerable: false
             });
+        }
+
+        if(options.ffmpegPath) {
+            if(typeof options.ffmpegPath !== "string") throw new TypeError(`Expected type "string" for options.ffmpegPath. Got ${typeof options.ffmpegPath} instead`)
+            if(!existsSync(options.ffmpegPath)) throw new Error(`The pathway provided for options.ffmpegPath does not exists.`)
+
+            process.env.FFMPEG_PATH = options.ffmpegPath
         }
     }
 

--- a/packages/discord-player/src/Player.ts
+++ b/packages/discord-player/src/Player.ts
@@ -105,6 +105,13 @@ export class Player extends PlayerEventsEmitter<PlayerEvents> {
 
         super([PlayerEvent.Error]);
 
+        if(options.ffmpegPath) {
+            if(typeof options.ffmpegPath !== "string") throw new TypeError(`Expected type "string" for options.ffmpegPath. Got ${typeof options.ffmpegPath} instead`)
+            if(!existsSync(options.ffmpegPath)) throw new Error(`The pathway provided for options.ffmpegPath does not exists.`)
+
+            process.env.FFMPEG_PATH = options.ffmpegPath
+        }
+
         /**
          * The discord.js client
          * @type {Client}
@@ -173,13 +180,6 @@ export class Player extends PlayerEventsEmitter<PlayerEvents> {
                 configurable: true,
                 enumerable: false
             });
-        }
-
-        if(options.ffmpegPath) {
-            if(typeof options.ffmpegPath !== "string") throw new TypeError(`Expected type "string" for options.ffmpegPath. Got ${typeof options.ffmpegPath} instead`)
-            if(!existsSync(options.ffmpegPath)) throw new Error(`The pathway provided for options.ffmpegPath does not exists.`)
-
-            process.env.FFMPEG_PATH = options.ffmpegPath
         }
     }
 

--- a/packages/discord-player/src/Player.ts
+++ b/packages/discord-player/src/Player.ts
@@ -18,8 +18,6 @@ import { IPRotator } from './utils/IPRotator';
 import { Context, createContext } from './hooks';
 import { HooksCtx } from './hooks/common';
 import { LrcLib } from './lrclib/LrcLib';
-import { existsSync } from 'fs';
-import { spawnSync } from 'child_process';
 
 const kSingleton = Symbol('InstanceDiscordPlayerSingleton');
 

--- a/packages/discord-player/src/types/types.ts
+++ b/packages/discord-player/src/types/types.ts
@@ -531,4 +531,8 @@ export interface PlayerInitOptions {
      * The probe timeout in milliseconds. Defaults to 5000.
      */
     probeTimeout?: number;
+    /**
+     * Configure ffmpeg path
+     */
+    ffmpegPath?: string;
 }


### PR DESCRIPTION
## Changes
Add ffmpegPath option to player instead of setting the path via process.env.FFMPEG_PATH

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.