### PR TITLE
fix: (emptyQueue event) edited throw to emit 'finish' when queue is empty

### DIFF
--- a/packages/discord-player/src/queue/GuildQueue.ts
+++ b/packages/discord-player/src/queue/GuildQueue.ts
@@ -1052,13 +1052,15 @@ export class GuildQueue<Meta = unknown> {
                 })} was marked as finished`
             );
 
-        if (track && !this.isTransitioning()) {
+        if (!this.isTransitioning()) {
             this.syncedLyricsProvider.unsubscribe();
             this.syncedLyricsProvider.lyrics.clear();
             if (this.hasDebugger) this.debug('Adding track to history and emitting finish event since transition mode is disabled...');
-            this.history.push(track);
-            this.node.resetProgress();
-            this.emit(GuildQueueEvent.playerFinish, this, track);
+            if (track) {
+                this.history.push(track);
+                this.node.resetProgress();
+                this.emit(GuildQueueEvent.playerFinish, this, track);
+            }
             if (this.#deleted) return this.#emitEnd();
             if (this.tracks.size < 1 && this.repeatMode === QueueRepeatMode.OFF) {
                 if (this.hasDebugger) this.debug('No more tracks left in the queue to play and repeat mode is off, initiating #emitEnd()');
@@ -1073,7 +1075,7 @@ export class GuildQueue<Meta = unknown> {
                     if (this.hasDebugger) this.debug('Repeat mode is set to queue, moving last track from the history to current queue...');
                     this.tracks.add(this.history.tracks.dispatch() || track);
                 }
-                if (!this.tracks.size) {
+                if (!this.tracks.size && track) {
                     if (this.repeatMode === QueueRepeatMode.AUTOPLAY) {
                         if (this.hasDebugger) this.debug('Repeat mode is set to autoplay, initiating autoplay handler...');
                         this.#handleAutoplay(track);

--- a/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
+++ b/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
@@ -688,7 +688,6 @@ export class GuildQueuePlayerNode<Meta = unknown> {
         const nextTrack = this.queue.tracks.dispatch();
         if (nextTrack) return void this.play(nextTrack, { queue: false });
         this.queue.dispatcher.emit("finish");
-        return;
     }
 
     async #performPlay(resource: AudioResource<Track>) {

--- a/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
+++ b/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
@@ -687,7 +687,7 @@ export class GuildQueuePlayerNode<Meta = unknown> {
         this.queue.emit(GuildQueueEvent.playerError, this.queue, streamDefinitelyFailedMyDearT_TPleaseTrustMeItsNotMyFault, track);
         const nextTrack = this.queue.tracks.dispatch();
         if (nextTrack) return void this.play(nextTrack, { queue: false });
-        this.queue.dispatcher.emit('finish');
+        this.queue.dispatcher.emit("finish");
         return;
     }
 

--- a/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
+++ b/packages/discord-player/src/queue/GuildQueuePlayerNode.ts
@@ -686,7 +686,8 @@ export class GuildQueuePlayerNode<Meta = unknown> {
         this.queue.emit(GuildQueueEvent.playerSkip, this.queue, track, TrackSkipReason.NoStream, streamDefinitelyFailedMyDearT_TPleaseTrustMeItsNotMyFault.message);
         this.queue.emit(GuildQueueEvent.playerError, this.queue, streamDefinitelyFailedMyDearT_TPleaseTrustMeItsNotMyFault, track);
         const nextTrack = this.queue.tracks.dispatch();
-        if (nextTrack) this.play(nextTrack, { queue: false });
+        if (nextTrack) return void this.play(nextTrack, { queue: false });
+        this.queue.dispatcher.emit('finish');
         return;
     }
 


### PR DESCRIPTION
## Changes
+ edited GuildQueuePlayerNode.ts: #throw to emit 'finish' when the queue is empty
+ edited GuildQueue.ts: #performFinish to run even if track is null.

## Status
emptyQueue event now triggers correctly after playerError event.

- [X] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.