### PR TITLE
Change from import * as to import type

### DIFF
--- a/packages/discord-player/src/compat/createOceanicCompat.ts
+++ b/packages/discord-player/src/compat/createOceanicCompat.ts
@@ -12,7 +12,7 @@ import {
   GatewayVoiceStateUpdateDispatchData,
   VoiceState,
 } from 'discord.js';
-import * as Oceanic from 'oceanic.js';
+import type Oceanic from 'oceanic.js';
 
 type OceanicUserResolvable = Oceanic.User | string | Oceanic.Member;
 type OceanicGuildResolvable =


### PR DESCRIPTION
## Changes
[7.2.0-dev.0](https://www.npmjs.com/package/discord-player/v/7.2.0-dev.0) was requiring oceanic.js on discord.js bots. I believe this should fix the issue

## Status

- [X] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.