### PR TITLE
chore: keep youtube params

### DIFF
--- a/packages/discord-player/src/utils/QueryResolver.ts
+++ b/packages/discord-player/src/utils/QueryResolver.ts
@@ -211,18 +211,11 @@ class QueryResolver {
       if (DomainsMap.YouTube.includes(url.host)) {
         query = query.replace(/(m(usic)?|gaming)\./, '').trim();
         const playlistId = url.searchParams.get('list');
-        const videoId = url.searchParams.get('v');
-        if (playlistId) {
-          if (videoId && playlistId.startsWith('RD'))
-            return resolver(
-              QueryType.YOUTUBE_PLAYLIST,
-              `https://www.youtube.com/watch?v=${videoId}&list=${playlistId}`,
-            );
+        if (playlistId)
           return resolver(
             QueryType.YOUTUBE_PLAYLIST,
-            `https://www.youtube.com/playlist?list=${playlistId}`,
+            `https://www.youtube.com/${url.searchParams.size === 1 ? "playlist" : "watch"}${url.search}`,
           );
-        }
         if (QueryResolver.validateId(query) || QueryResolver.validateURL(query))
           return resolver(QueryType.YOUTUBE_VIDEO, query);
         return resolver(fallbackSearchEngine, query);


### PR DESCRIPTION
## Changes
Keep all youtube params from URL. v/index (possibly other param) that needed to play the playlist from given URL index or other purposes.

## Status

- [X] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.