### PR TITLE
Update SpotifyExtractor.ts Thumbanil Song Fix

### DIFF
--- a/packages/extractor/src/extractors/SpotifyExtractor.ts
+++ b/packages/extractor/src/extractors/SpotifyExtractor.ts
@@ -148,7 +148,7 @@ export class SpotifyExtractor extends BaseExtractor<SpotifyExtractorInit> {
             ? `https://open.spotify.com/track/${spotifyData.id}`
             : query,
           thumbnail:
-            spotifyData.coverArt?.sources?.[0]?.url ||
+            spotifyData.visualIdentity?.image?.[0]?.url ||
             'https://www.scdn.co/i/_global/twitter_card-default.jpg',
           duration: Util.buildTimeCode(
             Util.parseMS(spotifyData.duration ?? spotifyData.maxDuration ?? 0),


### PR DESCRIPTION
## Changes
<!-- describe what changes this PR includes and explain why are they needed -->

This PR updates the line that fetches the thumbnail from spotifyData specifically for the QueryType.SPOTIFY_SONG case.

As shown in the first screenshot, the previous implementation always returned the same image. The second screenshot shows the corrected line, which now retrieves the proper song thumbnail.

I tested this manually for several hours to ensure the fix works correctly and consistently.

## Status

- [x] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.

![image](https://github.com/user-attachments/assets/9ae58f60-1562-4ec8-b2cd-7d853a2615eb)
![image](https://github.com/user-attachments/assets/84405cf1-2e02-4245-b2ad-483ac02e086b)
