### PR TITLE
docs(extractors): remove vkmusic extractor

### DIFF
--- a/apps/website/lib/data/showcase.ts
+++ b/apps/website/lib/data/showcase.ts
@@ -239,11 +239,6 @@ export const ShowcaseResource: IShowcase = {
       url: 'https://npm.im/discord-player-deezer',
     },
     {
-      name: 'discord-player-vkmusic',
-      description: 'An unofficial discord-player extractor for VK Music.',
-      url: 'https://npm.im/discord-player-vkmusic',
-    },
-    {
       name: 'discord-player-yandexmusic',
       description: 'Unofficial discord-player extractor for Yandex Music.',
       url: 'https://npm.im/discord-player-yandexmusic',


### PR DESCRIPTION
## Changes

Although I added this extractor only a few days ago, after a bit of reflection I decided to remove the package from public access since extracting music from VK violates their terms of service and I do not want to put either myself or those who might want to use it at risk.

Of course, I should have thought about this before creating the pull request to add the extractor to the documentation, and I apologize for taking your time and slightly cluttering the commit history.

Even though it was brief, I was glad to feel part of the discord-player community, and I hope that if I decide to come back in the future, you will welcome me :)

## Status

- [ ] These changes have been tested and formatted properly.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.