### PR TITLE
fix(equalizer): prevent DSP filter chain from creating unused filters

### DIFF
--- a/packages/equalizer/src/FiltersChainBuilder.ts
+++ b/packages/equalizer/src/FiltersChainBuilder.ts
@@ -50,37 +50,45 @@ export class FiltersChain {
 
     this.source = src;
 
-    const resampler = !presets.resampler?.disabled
-      ? new PCMResampler(presets.resampler)
-      : null;
+    const resampler =
+      presets.resampler && !presets.resampler.disabled
+        ? new PCMResampler(presets.resampler)
+        : null;
 
-    const equalizerStream = !presets.equalizer?.disabled
-      ? new EqualizerStream(presets.equalizer)
-      : null;
+    const equalizerStream =
+      presets.equalizer && !presets.equalizer.disabled
+        ? new EqualizerStream(presets.equalizer)
+        : null;
 
-    const dspStream = !presets.dsp?.disabled
-      ? new AudioFilter(presets.dsp)
-      : null;
+    const dspStream =
+      presets.dsp && !presets.dsp.disabled
+        ? new AudioFilter(presets.dsp)
+        : null;
 
-    const biquadStream = !presets.biquad?.disabled
-      ? new BiquadStream(presets.biquad)
-      : null;
+    const biquadStream =
+      presets.biquad && !presets.biquad.disabled
+        ? new BiquadStream(presets.biquad)
+        : null;
 
-    const volumeTransformer = !presets.volume?.disabled
-      ? new VolumeTransformer(presets.volume)
-      : null;
+    const volumeTransformer =
+      presets.volume && !presets.volume.disabled
+        ? new VolumeTransformer(presets.volume)
+        : null;
 
-    const compressor = !presets.compressor?.disabled
-      ? new CompressorTransformer(presets.compressor)
-      : null;
+    const compressor =
+      presets.compressor && !presets.compressor.disabled
+        ? new CompressorTransformer(presets.compressor)
+        : null;
 
-    const seeker = !presets.seeker?.disabled
-      ? new PCMSeekerTransformer(presets.seeker)
-      : null;
+    const seeker =
+      presets.seeker && !presets.seeker.disabled
+        ? new PCMSeekerTransformer(presets.seeker)
+        : null;
 
-    const reverb = !presets.reverb?.disabled
-      ? new ReverbTransformer(presets.reverb)
-      : null;
+    const reverb =
+      presets.reverb && !presets.reverb.disabled
+        ? new ReverbTransformer(presets.reverb)
+        : null;
 
     this.resampler = resampler;
     this.equalizer = equalizerStream;


### PR DESCRIPTION
## Changes

Filters in the DSP chain are now only instantiated when their configuration preset is explicitly provided.

## Problem

`FiltersChain.create()` used the following condition to decide whether to instantiate a filter:

```typescript
const resampler = !presets.resampler?.disabled
  ? new PCMResampler(presets.resampler)
  : null;
```

When `presets.X` is `undefined`, `presets.X?.disabled` evaluates to `undefined`, and `!undefined` evaluates to `true`, causing the filter to be instantiated with `undefined` options. 

With default configs, this made it so some filters were not possible to disable via `GuildNodeCreateOptions` (see [`StreamDispatcher.ts`](https://github.com/Androz2091/discord-player/blob/master/packages/discord-player/src/stream/StreamDispatcher.ts#L359-L416)

## Fix 

Changed conditions to `presets.X && !presets.X.disabled`

## Status

- [X] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.